### PR TITLE
fix(a11y): theme-aware accent colors with WCAG AA contrast

### DIFF
--- a/src/layouts/NoteLayout.astro
+++ b/src/layouts/NoteLayout.astro
@@ -69,7 +69,7 @@ const publishDateLabel = data.publishDate.toLocaleDateString('en-AU', {
     </header>
 
     <div
-      class="prose prose-invert max-w-none prose-headings:font-mono prose-headings:tracking-tight prose-a:text-brand-body prose-a:underline-offset-4 prose-pre:rounded-lg prose-pre:border prose-pre:border-border-base/60"
+      class="prose max-w-none dark:prose-invert prose-headings:font-mono prose-headings:tracking-tight prose-a:text-brand-body prose-a:underline-offset-4 prose-pre:rounded-lg prose-pre:border prose-pre:border-border-base/60"
     >
       <slot />
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,6 +12,16 @@
     --text-primary: 30 41 59; /* slate-800 */
     /* slate-600 #475569 — 7.19:1 on bg-base, comfortable AAA */
     --text-muted: 71 85 105;
+
+    /* Light-theme accent colors — all ≥ 4.5:1 on #f8f9fa */
+    --accent-brand: 109 40 217; /* #6d28d9  ~6.8:1 */
+    --accent-brand-body: 109 40 217;
+    --accent-status: 21 128 61; /* #15803d  ~4.6:1 */
+    --accent-infra: 14 116 144; /* #0e7490  ~4.5:1 */
+    --accent-impact: 194 65 12; /* #c2410c  ~5.3:1 */
+    --accent-human: 190 24 93; /* #be185d  ~5.2:1 */
+    --accent-stack: 161 98 7; /* #a16207  ~5.0:1 */
+    --accent-danger: 185 28 28; /* #b91c1c  ~5.7:1 */
   }
 
   :root.dark {
@@ -24,6 +34,16 @@
     /* Brightened Dracula comment #7a8bc0 — 5.66:1 on bg-base, AA with margin.
        Original #6272a4 was 4.02:1 and fails 12px body-copy WCAG 1.4.3. */
     --text-muted: 122 139 192;
+
+    /* Dracula accent colors */
+    --accent-brand: 189 147 249; /* #bd93f9 */
+    --accent-brand-body: 196 160 255; /* #c4a0ff */
+    --accent-status: 80 250 123; /* #50fa7b */
+    --accent-infra: 139 233 253; /* #8be9fd */
+    --accent-impact: 255 184 108; /* #ffb86c */
+    --accent-human: 255 121 198; /* #ff79c6 */
+    --accent-stack: 241 250 140; /* #f1fa8c */
+    --accent-danger: 255 85 85; /* #ff5555 */
   }
 
   html {
@@ -38,7 +58,7 @@
   }
 
   ::selection {
-    background-color: #bd93f9;
+    background-color: rgb(var(--accent-brand));
     color: #0d1117;
   }
 
@@ -56,7 +76,7 @@
 
   /* Focus-visible ring — brand purple on any interactive */
   *:focus-visible {
-    outline: 2px solid #bd93f9;
+    outline: 2px solid rgb(var(--accent-brand));
     outline-offset: 2px;
     border-radius: 2px;
   }

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -15,18 +15,17 @@ export default {
         'text-primary': 'rgb(var(--text-primary) / <alpha-value>)',
         'text-muted': 'rgb(var(--text-muted) / <alpha-value>)',
 
-        // Dracula semantic accents
+        // Theme-aware semantic accents (CSS vars switch in global.css)
         brand: {
-          // Purple — links, hero, brand. body-size uses lightened variant
-          DEFAULT: '#bd93f9',
-          body: '#c4a0ff'
+          DEFAULT: 'rgb(var(--accent-brand) / <alpha-value>)',
+          body: 'rgb(var(--accent-brand-body) / <alpha-value>)'
         },
-        status: '#50fa7b', // Green — availability, OSS
-        infra: '#8be9fd', // Cyan — infrastructure tags
-        impact: '#ffb86c', // Orange — metrics, CTA
-        human: '#ff79c6', // Pink — philosophy, social good
-        stack: '#f1fa8c', // Yellow — tech stack tags
-        danger: '#ff5555' // Red — errors, destructive
+        status: 'rgb(var(--accent-status) / <alpha-value>)',
+        infra: 'rgb(var(--accent-infra) / <alpha-value>)',
+        impact: 'rgb(var(--accent-impact) / <alpha-value>)',
+        human: 'rgb(var(--accent-human) / <alpha-value>)',
+        stack: 'rgb(var(--accent-stack) / <alpha-value>)',
+        danger: 'rgb(var(--accent-danger) / <alpha-value>)'
       },
       fontFamily: {
         sans: [
@@ -83,11 +82,11 @@ export default {
           css: {
             '--tw-prose-body': 'rgb(var(--text-primary))',
             '--tw-prose-headings': 'rgb(var(--text-primary))',
-            '--tw-prose-links': '#c4a0ff',
+            '--tw-prose-links': 'rgb(var(--accent-brand-body))',
             '--tw-prose-bold': 'rgb(var(--text-primary))',
-            '--tw-prose-code': '#f1fa8c',
-            '--tw-prose-pre-bg': '#161b22',
-            '--tw-prose-pre-code': '#f8f8f2',
+            '--tw-prose-code': 'rgb(var(--accent-stack))',
+            '--tw-prose-pre-bg': 'rgb(var(--bg-surface))',
+            '--tw-prose-pre-code': 'rgb(var(--text-primary))',
             '--tw-prose-quotes': 'rgb(var(--text-muted))',
             '--tw-prose-hr': 'rgb(var(--border-base))',
             'code::before': { content: '""' },


### PR DESCRIPTION
## Summary
- Move all hardcoded Dracula accent hex values behind CSS custom properties (`--accent-*`) that switch between dark (Dracula) and light (Paper) palettes
- Light-theme accent colors all meet **>= 4.5:1** contrast ratio on `#f8f9fa` (WCAG AA for normal text)
- Prose typography colors (links, code, pre blocks) are now theme-aware via the same CSS vars

## Changes
| File | What |
|------|------|
| `src/styles/global.css` | Added `--accent-{brand,status,infra,impact,human,stack,danger}` vars for `:root` (light) and `:root.dark` |
| `tailwind.config.mjs` | Replaced hardcoded hex with `rgb(var(--accent-*) / <alpha-value>)` pattern; prose overrides use CSS vars |
| `src/layouts/NoteLayout.astro` | `prose-invert` -> `dark:prose-invert` |

## Light-theme contrast ratios (on #f8f9fa)
| Token | Hex | Ratio |
|-------|-----|-------|
| brand | `#6d28d9` | ~6.8:1 |
| impact | `#c2410c` | ~5.3:1 |
| status | `#15803d` | ~4.6:1 |
| infra | `#0e7490` | ~4.5:1 |
| human | `#be185d` | ~5.2:1 |
| stack | `#a16207` | ~5.0:1 |
| danger | `#b91c1c` | ~5.7:1 |

## Test plan
- [x] `npm run build` succeeds
- [x] Dark theme: accent colors match original Dracula values (verified via computed styles)
- [x] Light theme: accent colors are darker variants with readable contrast (verified via computed styles)
- [ ] Visual check: toggle theme via ThemeToggle component on all pages
- [ ] Lighthouse accessibility audit passes

Generated with [Claude Code](https://claude.com/claude-code)