### PR TITLE
refactor(theme): migrate hardcoded hex accents to CSS custom properties

### DIFF
--- a/src/components/BentoCard.astro
+++ b/src/components/BentoCard.astro
@@ -12,7 +12,10 @@
  * Layout is controlled by the parent grid via `class` prop spanning utilities.
  */
 
-export type BentoAccent = 'brand' | 'infra' | 'impact' | 'human' | 'status' | 'stack';
+import { accentVar } from '@lib/accents';
+import type { AccentToken } from '@lib/accents';
+
+export type BentoAccent = AccentToken;
 
 export interface Props {
   /** Tailwind grid-span classes (e.g., 'col-span-2 row-span-2'). */
@@ -21,8 +24,6 @@ export interface Props {
   accent?: BentoAccent;
   /** Optional badge label (top-right ribbon). */
   badge?: string;
-  /** Optional badge accent hex (overrides accent token for the badge). */
-  badgeColor?: string;
   /** Optional href; makes the card a stretched-link block. */
   href?: string;
   /** External link rel, defaults to noopener for safety. */
@@ -35,7 +36,6 @@ const {
   class: klass = '',
   accent = 'brand',
   badge,
-  badgeColor,
   href,
   rel = 'noopener',
   ariaLabelledby
@@ -47,19 +47,9 @@ const accentClassMap: Record<BentoAccent, string> = {
   impact: 'hover:border-impact hover:shadow-glow-impact',
   human: 'hover:border-human hover:shadow-glow-human',
   status: 'hover:border-status hover:shadow-glow-status',
-  stack: 'hover:border-stack hover:shadow-glow-impact'
+  stack: 'hover:border-stack hover:shadow-glow-impact',
+  danger: 'hover:border-danger hover:shadow-glow-brand'
 };
-
-const accentBorderMap: Record<BentoAccent, string> = {
-  brand: '#bd93f9',
-  infra: '#8be9fd',
-  impact: '#ffb86c',
-  human: '#ff79c6',
-  status: '#50fa7b',
-  stack: '#f1fa8c'
-};
-
-const badgeFill = badgeColor ?? accentBorderMap[accent];
 ---
 
 <article
@@ -74,7 +64,7 @@ const badgeFill = badgeColor ?? accentBorderMap[accent];
     badge && (
       <span
         class="absolute right-3 top-3 z-10 rounded-full px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wider"
-        style={`background-color: ${badgeFill}1a; color: ${badgeFill}; border: 1px solid ${badgeFill}`}
+        style={`background-color: ${accentVar(accent, 0.1)}; color: ${accentVar(accent)}; border: 1px solid ${accentVar(accent)}`}
       >
         {badge}
       </span>

--- a/src/components/MetricCard.astro
+++ b/src/components/MetricCard.astro
@@ -11,6 +11,7 @@
 
 import type { Metric } from '@data/schemas';
 import MetricCounter from '@islands/MetricCounter.svelte';
+import { accentVar } from '@lib/accents';
 
 export interface Props {
   metric: Metric;
@@ -18,6 +19,7 @@ export interface Props {
 
 const { metric } = Astro.props;
 const { value, direction, label, context, methodology, confidenceBound, accent } = metric;
+const accentCss = accentVar(accent);
 
 const directionLabel = direction === '↑' ? 'increase' : direction === '↓' ? 'decrease' : 'measured';
 const a11yLabel = `${value} ${directionLabel}: ${label}`;
@@ -25,7 +27,7 @@ const a11yLabel = `${value} ${directionLabel}: ${label}`;
 
 <article
   class="group relative flex flex-col gap-2 rounded-md border border-border-base/60 bg-bg-surface/60 p-4 transition-all duration-200 hover:border-impact hover:shadow-glow-impact"
-  style={`--metric-accent: ${accent}`}
+  style={`--metric-accent: ${accentCss}`}
 >
   <div class="flex items-baseline gap-2 font-mono">
     <MetricCounter
@@ -33,11 +35,11 @@ const a11yLabel = `${value} ${directionLabel}: ${label}`;
       finalValue={value}
       ariaLabel={a11yLabel}
       class="text-3xl font-bold leading-none"
-      style={`color: ${accent}`}
+      style={`color: ${accentCss}`}
     />
     {
       direction && (
-        <span aria-hidden="true" class="text-xl leading-none" style={`color: ${accent}`}>
+        <span aria-hidden="true" class="text-xl leading-none" style={`color: ${accentCss}`}>
           {direction}
         </span>
       )

--- a/src/components/StatusBeacon.astro
+++ b/src/components/StatusBeacon.astro
@@ -7,14 +7,18 @@
  * keyframe defined in tailwind.config.mjs.
  */
 
+import { accentVar } from '@lib/accents';
+import type { AccentToken } from '@lib/accents';
+
 export interface Props {
-  /** Hex token for the beacon (status green by default). */
-  color?: string;
+  /** Semantic accent token for the beacon (status green by default). */
+  color?: AccentToken;
   /** Accessible label exposed to screen readers. */
   label?: string;
 }
 
-const { color = '#50fa7b', label = 'Currently available' } = Astro.props;
+const { color = 'status', label = 'Currently available' } = Astro.props;
+
 ---
 
 <span
@@ -25,9 +29,9 @@ const { color = '#50fa7b', label = 'Currently available' } = Astro.props;
   <span
     aria-hidden="true"
     class="absolute inline-flex h-full w-full rounded-full opacity-75 motion-safe:animate-pulse-ring"
-    style={`background-color: ${color}`}></span>
+    style={`background-color: ${accentVar(color)}`}></span>
   <span
     aria-hidden="true"
     class="relative inline-flex h-2.5 w-2.5 rounded-full"
-    style={`background-color: ${color}`}></span>
+    style={`background-color: ${accentVar(color)}`}></span>
 </span>

--- a/src/components/TechBadge.astro
+++ b/src/components/TechBadge.astro
@@ -1,15 +1,17 @@
 ---
 /**
- * Dracula-styled inline badge for tech tags / pills.
+ * Themed inline badge for tech tags / pills.
  *
  * Used in the Hero stack pills, Bento card tag rows, and the /stack badge
- * grid. Accent is set per-instance via inline CSS variables so we don't
- * generate one Tailwind class per Dracula colour.
+ * grid. Accent is set per-instance via a CSS custom property that chains to
+ * the global --accent-* tokens, so badges adapt when the theme switches.
  */
 
+import type { AccentToken } from '@lib/accents';
+
 export interface Props {
-  /** Hex accent colour (Dracula token). */
-  accent?: string;
+  /** Semantic accent token (resolves to a CSS custom property). */
+  accent?: AccentToken;
   /** Optional href turns the badge into an anchor. */
   href?: string;
   /** External link rel — defaults to noopener for safety. */
@@ -21,20 +23,20 @@ export interface Props {
 }
 
 const {
-  accent = '#bd93f9',
+  accent = 'brand',
   href,
   rel = 'noopener',
   variant = 'outline',
   class: klass = ''
 } = Astro.props;
 
-const styleVar = `--badge-accent: ${accent};`;
+const styleVar = `--badge-accent: var(--accent-${accent});`;
 
 const baseClasses = [
   'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-xs transition-all duration-150',
   variant === 'outline'
-    ? 'border-[color:var(--badge-accent)] bg-transparent text-[color:var(--badge-accent)] hover:bg-[color:var(--badge-accent)]/10'
-    : 'border-transparent bg-[color:var(--badge-accent)]/15 text-[color:var(--badge-accent)] hover:bg-[color:var(--badge-accent)]/25',
+    ? 'border-[color:rgb(var(--badge-accent))] bg-transparent text-[color:rgb(var(--badge-accent))] hover:bg-[rgb(var(--badge-accent)_/_0.1)]'
+    : 'border-transparent bg-[rgb(var(--badge-accent)_/_0.15)] text-[color:rgb(var(--badge-accent))] hover:bg-[rgb(var(--badge-accent)_/_0.25)]',
   klass
 ];
 ---

--- a/src/components/islands/RadarChart.svelte
+++ b/src/components/islands/RadarChart.svelte
@@ -82,7 +82,7 @@
           })
           .join(' ')}
         fill="none"
-        stroke="rgba(255,255,255,0.08)"
+        stroke="rgb(var(--text-primary) / 0.08)"
         stroke-width="1"
       />
     {/each}
@@ -94,7 +94,7 @@
         y1={center}
         x2={s.x}
         y2={s.y}
-        stroke="rgba(255,255,255,0.06)"
+        stroke="rgb(var(--text-primary) / 0.06)"
         stroke-width="1"
       />
     {/each}
@@ -102,8 +102,8 @@
     <!-- Data polygon -->
     <polygon
       points={dataPoints}
-      fill="rgba(189,147,249,0.30)"
-      stroke="#bd93f9"
+      fill="rgb(var(--accent-brand) / 0.30)"
+      stroke="rgb(var(--accent-brand))"
       stroke-width="2"
       stroke-linejoin="round"
     />
@@ -114,8 +114,8 @@
         cx={m.x}
         cy={m.y}
         r={activeIndex === i ? 6 : 4}
-        fill="#f1fa8c"
-        stroke="#0d1117"
+        fill="rgb(var(--accent-stack))"
+        stroke="rgb(var(--bg-base))"
         stroke-width="1.5"
         on:mouseenter={() => (activeIndex = i)}
         on:mouseleave={() => (activeIndex = null)}
@@ -137,7 +137,7 @@
         dominant-baseline="middle"
         class="font-mono"
         font-size="10"
-        fill={activeIndex === i ? '#bd93f9' : '#8be9fd'}
+        fill={activeIndex === i ? 'rgb(var(--accent-brand))' : 'rgb(var(--accent-infra))'}
       >
         {l.label}
       </text>
@@ -148,7 +148,7 @@
         dominant-baseline="middle"
         class="font-mono"
         font-size="9"
-        fill="rgb(98,114,164)"
+        fill="rgb(var(--text-muted))"
       >
         {l.score}/100
       </text>

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -21,7 +21,7 @@ export const experiences: Experience[] = [
         label: 'reduction in feature lead times across the GCP ML platform',
         context: 'Montu — GCP ML Platform',
         methodology: 'DORA metrics, pre/post Kubeflow + GitOps migration',
-        accent: '#ffb86c'
+        accent: 'impact'
       },
       {
         value: '97%+',
@@ -29,14 +29,14 @@ export const experiences: Experience[] = [
         label: 'reduction in change-failure rate after platform consolidation',
         context: 'Montu — DORA Outcomes',
         methodology: 'Incident DB diff, 6-month rolling',
-        accent: '#ffb86c'
+        accent: 'impact'
       },
       {
         value: '93%',
         label: 'clinical NLP accuracy (outperforming Google Healthcare NLP by 14 pts)',
         context: 'Montu — Clinical Document Intelligence',
         methodology: 'Held-out clinician-labelled validation set',
-        accent: '#ffb86c'
+        accent: 'impact'
       },
       {
         value: '0.87+',
@@ -44,7 +44,7 @@ export const experiences: Experience[] = [
         label: 'F1 PII redaction score on clinical log sanitisation',
         context: 'Montu — Privacy-by-Design Logging',
         methodology: 'Held-out clinician-annotated PII corpus, micro-F1',
-        accent: '#ffb86c'
+        accent: 'impact'
       }
     ],
     techHighlights: [
@@ -73,7 +73,7 @@ export const experiences: Experience[] = [
         label: 'average infrastructure cost optimisation across 10k+ energy sites',
         context: 'Amber — Energy Forecasting Platform',
         methodology: 'GCP billing diff, 6-month rolling, post-FinOps refactor',
-        accent: '#ffb86c'
+        accent: 'impact'
       }
     ],
     techHighlights: [
@@ -100,7 +100,7 @@ export const experiences: Experience[] = [
         label: 'link adoption gains via the personalised link-recommender',
         context: 'Linktree — Two-Tower Recommender',
         methodology: 'A/B test, 30-day window, user-cohort holdout',
-        accent: '#ffb86c'
+        accent: 'impact'
       },
       {
         value: '18-23%',
@@ -108,7 +108,7 @@ export const experiences: Experience[] = [
         label: 'profile subscription uplift across recommender experiments',
         context: 'Linktree — Profile Subscriptions',
         methodology: 'A/B uplift, 90-day cohort',
-        accent: '#ffb86c'
+        accent: 'impact'
       }
     ],
     techHighlights: [
@@ -134,7 +134,7 @@ export const experiences: Experience[] = [
         label: 'enterprise identity fraud detection on Kubeflow / GKE',
         context: 'ANZ — Enterprise ML Platform',
         methodology: 'Production deploy across multiple business units',
-        accent: '#8be9fd'
+        accent: 'infra'
       }
     ],
     techHighlights: [
@@ -155,7 +155,7 @@ export const experiences: Experience[] = [
         value: 'Platform',
         label: 'SageMaker platform extensions powering claims ML workloads',
         context: 'nib — ML Infrastructure',
-        accent: '#8be9fd'
+        accent: 'infra'
       }
     ],
     techHighlights: [
@@ -175,7 +175,7 @@ export const experiences: Experience[] = [
         value: 'Live',
         label: 'customer-request triaging chatbot in clinical operations',
         context: 'HammondCare — Triaging Chatbot',
-        accent: '#8be9fd'
+        accent: 'infra'
       }
     ],
     techHighlights: [
@@ -195,13 +195,13 @@ export const experiences: Experience[] = [
         value: '2nd',
         label: 'place at Cricket Australia DataJam 2020 (cross-functional team lead)',
         context: 'Eliiza — Cricket Australia DataJam',
-        accent: '#bd93f9'
+        accent: 'brand'
       },
       {
         value: 'Framework',
         label: '"Thea" document mining framework adopted across consulting engagements',
         context: 'Eliiza — Thea Document Mining',
-        accent: '#8be9fd'
+        accent: 'infra'
       }
     ],
     techHighlights: [

--- a/src/data/metrics.ts
+++ b/src/data/metrics.ts
@@ -22,7 +22,7 @@ export const metrics: Metric[] = [
     label: 'reduction in feature lead times across the GCP ML platform',
     context: 'Montu — Healthcare ML Platform (2023–2025)',
     methodology: 'DORA metrics, measured pre/post Kubeflow + GitOps platform migration',
-    accent: '#ffb86c'
+    accent: 'impact'
   },
   {
     value: '93%',
@@ -30,7 +30,7 @@ export const metrics: Metric[] = [
     label: 'clinical NLP accuracy — outperforming Google Healthcare NLP by 14 points',
     context: 'Montu — Clinical Document Intelligence',
     methodology: 'Held-out clinician-labelled validation set, 5-fold cross-validation',
-    accent: '#ffb86c'
+    accent: 'impact'
   },
   {
     value: '40%',
@@ -38,7 +38,7 @@ export const metrics: Metric[] = [
     label: 'average infrastructure cost reduction across 10k+ energy sites',
     context: 'Amber — Energy Forecasting Platform (2021–2023)',
     methodology: 'GCP billing diff over 6-month rolling window post-FinOps refactor',
-    accent: '#ffb86c'
+    accent: 'impact'
   },
   {
     value: '71.3%',
@@ -51,7 +51,7 @@ export const metrics: Metric[] = [
       upper: '74.5%',
       note: '95% CI bootstrapped over weekly cohorts'
     },
-    accent: '#ffb86c'
+    accent: 'impact'
   },
   {
     value: '70%',
@@ -59,7 +59,7 @@ export const metrics: Metric[] = [
     label: 'clinician case reviews automated by the care quality assessment pipeline',
     context: 'Montu — Care Quality Assessment',
     methodology: 'Automated-review count / total reviews, monthly rolling',
-    accent: '#ffb86c'
+    accent: 'impact'
   },
   {
     value: '0.87+',
@@ -67,6 +67,6 @@ export const metrics: Metric[] = [
     label: 'F1 PII redaction score on clinical log sanitisation',
     context: 'Montu — Privacy-by-Design Logging',
     methodology: 'Held-out clinician-annotated PII corpus, micro-averaged F1',
-    accent: '#ffb86c'
+    accent: 'impact'
   }
 ];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -18,7 +18,7 @@ export const projects: Project[] = [
     domain: 'GenAI & Agentic Systems',
     repoUrl: 'https://github.com/suryaavala/scaling-succotash',
     tags: ['GraphRAG', 'LangGraph', 'Kubernetes', 'Celery', 'Circuit Breakers'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: true,
     badgeLabel: 'Featured'
   },
@@ -30,7 +30,7 @@ export const projects: Project[] = [
     domain: 'GenAI & Agentic Systems',
     repoUrl: 'https://github.com/suryaavala/openclaude',
     tags: ['Multi-Agent', 'LangChain', 'Guardrails'],
-    accentColor: '#bd93f9',
+    accentColor: 'brand',
     featured: false
   },
 
@@ -43,7 +43,7 @@ export const projects: Project[] = [
     domain: 'Systems & Infrastructure',
     repoUrl: 'https://github.com/suryaavala/traffic_counter',
     tags: ['Python', 'Systems', 'O(1)', 'CPython'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: true,
     badgeLabel: 'Latest'
   },
@@ -55,7 +55,7 @@ export const projects: Project[] = [
     domain: 'Systems & Infrastructure',
     repoUrl: 'https://github.com/suryaavala/decloud',
     tags: ['FinOps', 'Cloud', 'Cost Optimisation'],
-    accentColor: '#ffb86c',
+    accentColor: 'impact',
     featured: false
   },
   {
@@ -65,7 +65,7 @@ export const projects: Project[] = [
     domain: 'Systems & Infrastructure',
     repoUrl: 'https://github.com/suryaavala/advancedcpp',
     tags: ['C++', 'Templates', 'Systems'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: false
   },
 
@@ -77,7 +77,7 @@ export const projects: Project[] = [
     domain: 'ML & Data Science',
     repoUrl: 'https://github.com/suryaavala/suncorp',
     tags: ['Insurance', 'Classification'],
-    accentColor: '#f1fa8c',
+    accentColor: 'stack',
     featured: false
   },
   {
@@ -87,7 +87,7 @@ export const projects: Project[] = [
     domain: 'ML & Data Science',
     repoUrl: 'https://github.com/suryaavala/stockprediction',
     tags: ['Time-Series', 'Forecasting'],
-    accentColor: '#f1fa8c',
+    accentColor: 'stack',
     featured: false
   },
   {
@@ -97,7 +97,7 @@ export const projects: Project[] = [
     domain: 'ML & Data Science',
     repoUrl: 'https://github.com/suryaavala/som',
     tags: ['SOM', 'Unsupervised', 'Math'],
-    accentColor: '#bd93f9',
+    accentColor: 'brand',
     featured: false
   },
   {
@@ -107,7 +107,7 @@ export const projects: Project[] = [
     domain: 'ML & Data Science',
     repoUrl: 'https://github.com/suryaavala/prodr',
     tags: ['R', 'Production', 'Bridging'],
-    accentColor: '#f1fa8c',
+    accentColor: 'stack',
     featured: false
   },
   {
@@ -117,7 +117,7 @@ export const projects: Project[] = [
     domain: 'ML & Data Science',
     repoUrl: 'https://github.com/suryaavala/legimages',
     tags: ['Computer Vision', 'Composable'],
-    accentColor: '#f1fa8c',
+    accentColor: 'stack',
     featured: false
   },
 
@@ -129,7 +129,7 @@ export const projects: Project[] = [
     domain: 'Data Engineering & Tooling',
     repoUrl: 'https://github.com/suryaavala/zen_search',
     tags: ['Search', 'Indexing', 'Performance'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: false
   },
   {
@@ -139,7 +139,7 @@ export const projects: Project[] = [
     domain: 'Data Engineering & Tooling',
     repoUrl: 'https://github.com/suryaavala/fwfparser',
     tags: ['Parser', 'Streaming'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: false
   },
   {
@@ -149,7 +149,7 @@ export const projects: Project[] = [
     domain: 'Data Engineering & Tooling',
     repoUrl: 'https://github.com/suryaavala/ah_chambers_of_law',
     tags: ['Legal NLP', 'Extraction'],
-    accentColor: '#ff79c6',
+    accentColor: 'human',
     featured: false
   },
   {
@@ -159,7 +159,7 @@ export const projects: Project[] = [
     domain: 'Data Engineering & Tooling',
     repoUrl: 'https://github.com/suryaavala/template_cookiecutter',
     tags: ['Tooling', 'Scaffolding'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: false
   },
 
@@ -172,7 +172,7 @@ export const projects: Project[] = [
     domain: 'Enterprise ML & Document Intelligence',
     repoUrl: 'https://github.com/suryaavala/suryaavala.github.io',
     tags: ['Fraud', 'Kubeflow', 'GKE', 'Enterprise'],
-    accentColor: '#ffb86c',
+    accentColor: 'impact',
     featured: false
   },
   {
@@ -182,7 +182,7 @@ export const projects: Project[] = [
     domain: 'Enterprise ML & Document Intelligence',
     repoUrl: 'https://github.com/suryaavala/suryaavala.github.io',
     tags: ['NLU', 'Healthcare', 'Chatbot'],
-    accentColor: '#ff79c6',
+    accentColor: 'human',
     featured: false
   },
   {
@@ -192,7 +192,7 @@ export const projects: Project[] = [
     domain: 'Enterprise ML & Document Intelligence',
     repoUrl: 'https://github.com/suryaavala/suryaavala.github.io',
     tags: ['SageMaker', 'AWS', 'Healthcare'],
-    accentColor: '#8be9fd',
+    accentColor: 'infra',
     featured: false
   },
   {
@@ -203,7 +203,7 @@ export const projects: Project[] = [
     domain: 'Enterprise ML & Document Intelligence',
     repoUrl: 'https://github.com/suryaavala/suryaavala.github.io',
     tags: ['Document Mining', 'NLP', 'Framework'],
-    accentColor: '#bd93f9',
+    accentColor: 'brand',
     featured: false
   },
   {
@@ -214,7 +214,7 @@ export const projects: Project[] = [
     domain: 'Enterprise ML & Document Intelligence',
     repoUrl: 'https://github.com/suryaavala/suryaavala.github.io',
     tags: ['Sports Analytics', 'Competition'],
-    accentColor: '#bd93f9',
+    accentColor: 'brand',
     featured: false
   }
 ];

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -8,13 +8,11 @@
  */
 
 import { z } from 'zod';
+import { ACCENT_TOKENS } from '@lib/accents';
 
-const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}$/;
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
-export const HexColor = z
-  .string()
-  .regex(HEX_COLOR_REGEX, 'must be a 6-digit hex colour, e.g. "#bd93f9"');
+export const AccentTokenSchema = z.enum(ACCENT_TOKENS);
 export const IsoDate = z.string().regex(ISO_DATE_REGEX, 'must be ISO date YYYY-MM-DD');
 
 export const ConfidenceBoundSchema = z.object({
@@ -30,7 +28,7 @@ export const MetricSchema = z.object({
   context: z.string().min(5, 'Context must identify the company/project'),
   methodology: z.string().min(10, 'Methodology must explain measurement approach').optional(),
   confidenceBound: ConfidenceBoundSchema.optional(),
-  accent: HexColor
+  accent: AccentTokenSchema
 });
 
 export const ExperienceSchema = z.object({
@@ -59,7 +57,7 @@ export const ProjectSchema = z.object({
   domain: ProjectDomain,
   repoUrl: z.string().url(),
   tags: z.array(z.string()).min(1).max(8),
-  accentColor: HexColor,
+  accentColor: AccentTokenSchema,
   featured: z.boolean(),
   badgeLabel: z.enum(['Featured', 'Latest']).optional()
 });
@@ -72,7 +70,7 @@ export const CompetencyAxisSchema = z.object({
 
 export const StackCategorySchema = z.object({
   name: z.string().min(1),
-  accent: HexColor,
+  accent: AccentTokenSchema,
   items: z.array(z.string()).min(1)
 });
 

--- a/src/data/stack.ts
+++ b/src/data/stack.ts
@@ -10,7 +10,7 @@ import type { StackCategory } from './schemas';
 export const stackCategories: StackCategory[] = [
   {
     name: 'Languages & CS Primitives',
-    accent: '#8be9fd',
+    accent: 'infra',
     items: [
       'Python (Asyncio, Metaprogramming)',
       'C / C++',
@@ -22,7 +22,7 @@ export const stackCategories: StackCategory[] = [
   },
   {
     name: 'AI/ML & HPC',
-    accent: '#ffb86c',
+    accent: 'impact',
     items: [
       'PyTorch',
       'TensorFlow',
@@ -37,7 +37,7 @@ export const stackCategories: StackCategory[] = [
   },
   {
     name: 'Agentic & GenAI',
-    accent: '#bd93f9',
+    accent: 'brand',
     items: [
       'LangChain',
       'LangGraph',
@@ -55,7 +55,7 @@ export const stackCategories: StackCategory[] = [
   },
   {
     name: 'MLOps & Data Engineering',
-    accent: '#50fa7b',
+    accent: 'status',
     items: [
       'Kubeflow',
       'ClearML',
@@ -74,7 +74,7 @@ export const stackCategories: StackCategory[] = [
   },
   {
     name: 'Cloud & Infrastructure',
-    accent: '#8be9fd',
+    accent: 'infra',
     items: [
       'GCP (GKE, Cloud Run, VertexAI, Pub/Sub)',
       'AWS (EKS, SageMaker, Lambda, DynamoDB)',
@@ -88,7 +88,7 @@ export const stackCategories: StackCategory[] = [
   },
   {
     name: 'Advanced DL Paradigms',
-    accent: '#ff79c6',
+    accent: 'human',
     items: [
       'PEFT (LoRA / QLoRA)',
       'RLHF (PPO / DPO)',
@@ -98,7 +98,7 @@ export const stackCategories: StackCategory[] = [
   },
   {
     name: 'Systems Architecture & Theory',
-    accent: '#f1fa8c',
+    accent: 'stack',
     items: [
       'Distributed Systems Theory (CAP, PACELC, Paxos / Raft)',
       'Event-Driven Architecture',

--- a/src/lib/accents.ts
+++ b/src/lib/accents.ts
@@ -1,0 +1,31 @@
+/**
+ * Semantic accent tokens — single source for mapping logical colour names
+ * to CSS custom properties defined in global.css.
+ *
+ * Data files store token names ('brand', 'infra', …) instead of hex values.
+ * Components resolve tokens to `rgb(var(--accent-*))` via the helpers here,
+ * so accents automatically adapt when the theme switches between dark/light.
+ */
+
+export const ACCENT_TOKENS = [
+  'brand',
+  'status',
+  'infra',
+  'impact',
+  'human',
+  'stack',
+  'danger'
+] as const;
+
+export type AccentToken = (typeof ACCENT_TOKENS)[number];
+
+/** Returns a CSS `rgb(var(--accent-<token>))` string, with optional alpha. */
+export function accentVar(token: AccentToken, alpha?: number): string {
+  const v = `var(--accent-${token})`;
+  return alpha !== undefined ? `rgb(${v} / ${alpha})` : `rgb(${v})`;
+}
+
+/** Lookup map: token name -> CSS rgb(var(...)) string (full opacity). */
+export const accent: Record<AccentToken, string> = Object.fromEntries(
+  ACCENT_TOKENS.map((t) => [t, accentVar(t)])
+) as Record<AccentToken, string>;

--- a/src/pages/architecture.astro
+++ b/src/pages/architecture.astro
@@ -11,6 +11,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import BentoCard from '@components/BentoCard.astro';
 import TechBadge from '@components/TechBadge.astro';
 import GradientDivider from '@components/GradientDivider.astro';
+import { accentVar } from '@lib/accents';
 
 import { projects, upstreamPRs } from '@data/projects';
 import { ProjectDomain } from '@data/schemas';
@@ -72,13 +73,12 @@ const accentForDomain: Record<string, 'brand' | 'infra' | 'impact' | 'human' | '
                 href={project.repoUrl}
                 rel="noopener external"
                 badge={project.badgeLabel}
-                badgeColor={project.accentColor}
                 ariaLabelledby={`project-${project.slug}`}
               >
                 <h3
                   id={`project-${project.slug}`}
                   class="font-mono text-base text-text-primary"
-                  style={`color: ${project.accentColor}`}
+                  style={`color: ${accentVar(project.accentColor)}`}
                 >
                   {project.title}
                 </h3>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,13 +47,15 @@ if (!featured || !latest) {
   );
 }
 
-const stackPills: { label: string; accent: string }[] = [
-  { label: 'Python', accent: '#f1fa8c' },
-  { label: 'C++', accent: '#8be9fd' },
-  { label: 'Kubernetes', accent: '#8be9fd' },
-  { label: 'PyTorch', accent: '#ffb86c' },
-  { label: 'vLLM', accent: '#ffb86c' },
-  { label: 'LangGraph', accent: '#bd93f9' }
+import type { AccentToken } from '@lib/accents';
+
+const stackPills: { label: string; accent: AccentToken }[] = [
+  { label: 'Python', accent: 'stack' },
+  { label: 'C++', accent: 'infra' },
+  { label: 'Kubernetes', accent: 'infra' },
+  { label: 'PyTorch', accent: 'impact' },
+  { label: 'vLLM', accent: 'impact' },
+  { label: 'LangGraph', accent: 'brand' }
 ];
 ---
 
@@ -135,7 +137,7 @@ const stackPills: { label: string; accent: string }[] = [
       {/* ── 3. Status Card (1x1) — Open to Work ──────────────────────────── */}
       <BentoCard accent="status" ariaLabelledby="status-title">
         <header class="flex items-center gap-2">
-          <StatusBeacon color="#50fa7b" label="Currently open to work" />
+          <StatusBeacon color="status" label="Currently open to work" />
           <h2 id="status-title" class="font-mono text-sm uppercase tracking-widest text-status">
             Open to Work
           </h2>
@@ -160,7 +162,6 @@ const stackPills: { label: string; accent: string }[] = [
         accent="infra"
         class="md:col-span-2 lg:col-span-2"
         badge={featured.badgeLabel}
-        badgeColor={featured.accentColor}
         href={featured.repoUrl}
         rel="noopener external"
         ariaLabelledby="agentic-title"
@@ -176,7 +177,7 @@ const stackPills: { label: string; accent: string }[] = [
           {
             featured.tags.slice(0, 5).map((tag) => (
               <li>
-                <TechBadge accent="#8be9fd">{tag}</TechBadge>
+                <TechBadge accent="infra">{tag}</TechBadge>
               </li>
             ))
           }
@@ -187,7 +188,6 @@ const stackPills: { label: string; accent: string }[] = [
       <BentoCard
         accent="infra"
         badge={latest.badgeLabel}
-        badgeColor={latest.accentColor}
         href={latest.repoUrl}
         rel="noopener external"
         ariaLabelledby="infra-title"
@@ -201,7 +201,7 @@ const stackPills: { label: string; accent: string }[] = [
           {
             latest.tags.slice(0, 4).map((tag) => (
               <li>
-                <TechBadge accent="#8be9fd">{tag}</TechBadge>
+                <TechBadge accent="infra">{tag}</TechBadge>
               </li>
             ))
           }

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -11,19 +11,21 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '@layouts/BaseLayout.astro';
 import GradientDivider from '@components/GradientDivider.astro';
 import TechBadge from '@components/TechBadge.astro';
+import { accentVar } from '@lib/accents';
+import type { AccentToken } from '@lib/accents';
 
 const isProd = import.meta.env.PROD;
 const allNotes = await getCollection('notes', ({ data }) => (isProd ? !data.isDraft : true));
 const notes = allNotes.sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
 
-const categoryAccents: Record<string, string> = {
-  'Healthcare & Clinical NLP': '#ff79c6',
-  'Energy & Time-Series': '#50fa7b',
-  'Recommender Systems': '#bd93f9',
-  'Distributed Systems': '#8be9fd',
-  'GenAI Architecture': '#bd93f9',
-  'Mathematical Substrates': '#f1fa8c',
-  'Philosophy & Public Policy': '#ffb86c'
+const categoryAccents: Record<string, AccentToken> = {
+  'Healthcare & Clinical NLP': 'human',
+  'Energy & Time-Series': 'status',
+  'Recommender Systems': 'brand',
+  'Distributed Systems': 'infra',
+  'GenAI Architecture': 'brand',
+  'Mathematical Substrates': 'stack',
+  'Philosophy & Public Policy': 'impact'
 };
 ---
 
@@ -53,7 +55,7 @@ const categoryAccents: Record<string, string> = {
     <ul class="space-y-4" role="list">
       {
         notes.map((note) => {
-          const accent = categoryAccents[note.data.category] ?? '#bd93f9';
+          const accent = categoryAccents[note.data.category] ?? 'brand' as AccentToken;
           const dateISO = note.data.publishDate.toISOString().slice(0, 10);
           const dateLabel = note.data.publishDate.toLocaleDateString('en-AU', {
             year: 'numeric',
@@ -73,7 +75,7 @@ const categoryAccents: Record<string, string> = {
                   {note.data.requiresMath && (
                     <span
                       class="rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider"
-                      style="border-color: #f1fa8c; color: #f1fa8c"
+                      style={`border-color: ${accentVar('stack')}; color: ${accentVar('stack')}`}
                     >
                       math
                     </span>
@@ -93,7 +95,7 @@ const categoryAccents: Record<string, string> = {
                 <footer class="mt-3 flex flex-wrap items-center gap-2 font-mono text-xs text-text-muted">
                   <time datetime={dateISO}>{dateLabel}</time>
                   <span aria-hidden="true">·</span>
-                  <span style={`color: ${accent}`}>{note.data.category}</span>
+                  <span style={`color: ${accentVar(accent)}`}>{note.data.category}</span>
                   <span aria-hidden="true" class="ml-auto text-text-muted group-hover:text-brand">
                     read →
                   </span>

--- a/src/pages/ping.astro
+++ b/src/pages/ping.astro
@@ -10,12 +10,14 @@
 
 import BaseLayout from '@layouts/BaseLayout.astro';
 import GradientDivider from '@components/GradientDivider.astro';
+import { accentVar } from '@lib/accents';
+import type { AccentToken } from '@lib/accents';
 
 const channels: {
   channel: string;
   label: string;
   href: string;
-  accent: string;
+  accent: AccentToken;
   icon: string;
   rel?: string;
 }[] = [
@@ -23,7 +25,7 @@ const channels: {
     channel: 'GitHub',
     label: 'github.com/suryaavala',
     href: 'https://github.com/suryaavala',
-    accent: '#bd93f9',
+    accent: 'brand',
     icon: '⌥',
     rel: 'me noopener'
   },
@@ -31,7 +33,7 @@ const channels: {
     channel: 'LinkedIn',
     label: 'linkedin.com/in/suryaavala',
     href: 'https://linkedin.com/in/suryaavala',
-    accent: '#8be9fd',
+    accent: 'infra',
     icon: 'in',
     rel: 'me noopener'
   },
@@ -39,7 +41,7 @@ const channels: {
     channel: 'Email',
     label: 'suryaavinashavala@gmail.com',
     href: 'mailto:suryaavinashavala@gmail.com',
-    accent: '#50fa7b',
+    accent: 'status',
     icon: '@',
     rel: 'me'
   },
@@ -47,7 +49,7 @@ const channels: {
     channel: 'Buy Me a Coffee',
     label: 'buymeacoffee.com/suryaavala',
     href: 'https://buymeacoffee.com/suryaavala',
-    accent: '#f1fa8c',
+    accent: 'stack',
     icon: '☕',
     rel: 'noopener'
   },
@@ -55,7 +57,7 @@ const channels: {
     channel: 'GitHub Sponsors',
     label: 'github.com/sponsors/suryaavala',
     href: 'https://github.com/sponsors/suryaavala',
-    accent: '#ff79c6',
+    accent: 'human',
     icon: '♥',
     rel: 'noopener'
   }
@@ -88,19 +90,19 @@ const channels: {
               href={href}
               rel={rel}
               class="group flex items-center gap-4 rounded-lg border border-border-base/60 bg-bg-surface p-5 transition-all duration-200 hover:shadow-glow-brand"
-              style={`--ping-accent: ${accent}; --tw-shadow-color: ${accent}`}
+              style={`--ping-accent: ${accentVar(accent)}; --tw-shadow-color: ${accentVar(accent)}`}
             >
               <span
                 aria-hidden="true"
                 class="flex h-12 w-12 items-center justify-center rounded-md font-mono text-lg font-semibold transition-colors"
-                style={`background-color: ${accent}1a; color: ${accent}; border: 1px solid ${accent}55`}
+                style={`background-color: ${accentVar(accent, 0.1)}; color: ${accentVar(accent)}; border: 1px solid ${accentVar(accent, 0.33)}`}
               >
                 {icon}
               </span>
               <span class="flex flex-1 flex-col">
                 <span
                   class="font-mono text-sm uppercase tracking-widest"
-                  style={`color: ${accent}`}
+                  style={`color: ${accentVar(accent)}`}
                 >
                   {channel}
                 </span>
@@ -111,7 +113,7 @@ const channels: {
               <span
                 aria-hidden="true"
                 class="font-mono text-xs text-text-muted transition-transform group-hover:translate-x-1"
-                style={`color: ${accent}`}
+                style={`color: ${accentVar(accent)}`}
               >
                 →
               </span>

--- a/src/pages/runtime.astro
+++ b/src/pages/runtime.astro
@@ -14,13 +14,15 @@ import MetricCard from '@components/MetricCard.astro';
 import TechBadge from '@components/TechBadge.astro';
 
 import { experiences } from '@data/experiences';
+import { accentVar } from '@lib/accents';
+import type { AccentToken } from '@lib/accents';
 
-const industryAccents: Record<string, string> = {
-  Healthcare: '#ff79c6',
-  Energy: '#50fa7b',
-  Finance: '#8be9fd',
-  'Consumer Tech': '#bd93f9',
-  Consulting: '#f1fa8c'
+const industryAccents: Record<string, AccentToken> = {
+  Healthcare: 'human',
+  Energy: 'status',
+  Finance: 'infra',
+  'Consumer Tech': 'brand',
+  Consulting: 'stack'
 };
 ---
 
@@ -45,7 +47,7 @@ const industryAccents: Record<string, string> = {
     <ol class="space-y-8 sm:space-y-10" role="list">
       {
         experiences.map((exp, i) => {
-          const accent = industryAccents[exp.industry] ?? '#bd93f9';
+          const accent = industryAccents[exp.industry] ?? 'brand' as AccentToken;
           const headingId = `exp-${i}`;
           return (
             <li
@@ -57,7 +59,7 @@ const industryAccents: Record<string, string> = {
                   <h2
                     id={headingId}
                     class="font-mono text-lg text-text-primary sm:text-xl"
-                    style={`color: ${accent}`}
+                    style={`color: ${accentVar(accent)}`}
                   >
                     {exp.company}
                   </h2>
@@ -85,7 +87,7 @@ const industryAccents: Record<string, string> = {
                   <ul class="flex flex-wrap gap-1.5" role="list">
                     {exp.techHighlights.map((t) => (
                       <li>
-                        <TechBadge accent="#8be9fd">{t}</TechBadge>
+                        <TechBadge accent="infra">{t}</TechBadge>
                       </li>
                     ))}
                   </ul>

--- a/src/pages/stack.astro
+++ b/src/pages/stack.astro
@@ -11,6 +11,7 @@ import BaseLayout from '@layouts/BaseLayout.astro';
 import GradientDivider from '@components/GradientDivider.astro';
 import TechBadge from '@components/TechBadge.astro';
 import RadarChart from '@islands/RadarChart.svelte';
+import { accentVar } from '@lib/accents';
 
 import { competencyAxes } from '@data/competency';
 import { stackCategories } from '@data/stack';
@@ -84,17 +85,17 @@ import { stackCategories } from '@data/stack';
           stackCategories.map((cat) => (
             <article
               class="rounded-lg border border-border-base/60 bg-bg-surface/60 p-5 transition-all duration-200 hover:border-stack hover:shadow-glow-impact"
-              style={`--cat-accent: ${cat.accent}`}
+              style={`--cat-accent: var(--accent-${cat.accent})`}
             >
               <header class="mb-3 flex items-center gap-2">
                 <span
                   aria-hidden="true"
                   class="inline-block h-2 w-2 rounded-full"
-                  style={`background-color: ${cat.accent}`}
+                  style={`background-color: ${accentVar(cat.accent)}`}
                 />
                 <h3
                   class="font-mono text-sm uppercase tracking-widest"
-                  style={`color: ${cat.accent}`}
+                  style={`color: ${accentVar(cat.accent)}`}
                 >
                   {cat.name}
                 </h3>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,7 +35,7 @@
        Original #6272a4 was 4.02:1 and fails 12px body-copy WCAG 1.4.3. */
     --text-muted: 122 139 192;
 
-    /* Dracula accent colors */
+    /* Dracula accent palette — vivid on dark backgrounds */
     --accent-brand: 189 147 249; /* #bd93f9 */
     --accent-brand-body: 196 160 255; /* #c4a0ff */
     --accent-status: 80 250 123; /* #50fa7b */
@@ -59,7 +59,7 @@
 
   ::selection {
     background-color: rgb(var(--accent-brand));
-    color: #0d1117;
+    color: rgb(var(--bg-base));
   }
 
   /* Respect reduced motion */
@@ -86,13 +86,13 @@
   .dracula-rainbow {
     background: linear-gradient(
       90deg,
-      #ff5555 0%,
-      #ffb86c 16%,
-      #f1fa8c 33%,
-      #50fa7b 50%,
-      #8be9fd 66%,
-      #bd93f9 83%,
-      #ff79c6 100%
+      rgb(var(--accent-danger)) 0%,
+      rgb(var(--accent-impact)) 16%,
+      rgb(var(--accent-stack)) 33%,
+      rgb(var(--accent-status)) 50%,
+      rgb(var(--accent-infra)) 66%,
+      rgb(var(--accent-brand)) 83%,
+      rgb(var(--accent-human)) 100%
     );
   }
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -56,12 +56,17 @@ export default {
         bento: 'minmax(220px, auto)'
       },
       boxShadow: {
-        glow: '0 0 0 1px rgb(var(--border-base) / 0.6), 0 0 32px -8px rgb(189 147 249 / 0.25)',
-        'glow-brand': '0 0 0 1px #bd93f9, 0 0 32px -8px rgb(189 147 249 / 0.45)',
-        'glow-infra': '0 0 0 1px #8be9fd, 0 0 32px -8px rgb(139 233 253 / 0.45)',
-        'glow-impact': '0 0 0 1px #ffb86c, 0 0 32px -8px rgb(255 184 108 / 0.45)',
-        'glow-human': '0 0 0 1px #ff79c6, 0 0 32px -8px rgb(255 121 198 / 0.45)',
-        'glow-status': '0 0 0 1px #50fa7b, 0 0 32px -8px rgb(80 250 123 / 0.45)'
+        glow: '0 0 0 1px rgb(var(--border-base) / 0.6), 0 0 32px -8px rgb(var(--accent-brand) / 0.25)',
+        'glow-brand':
+          '0 0 0 1px rgb(var(--accent-brand)), 0 0 32px -8px rgb(var(--accent-brand) / 0.45)',
+        'glow-infra':
+          '0 0 0 1px rgb(var(--accent-infra)), 0 0 32px -8px rgb(var(--accent-infra) / 0.45)',
+        'glow-impact':
+          '0 0 0 1px rgb(var(--accent-impact)), 0 0 32px -8px rgb(var(--accent-impact) / 0.45)',
+        'glow-human':
+          '0 0 0 1px rgb(var(--accent-human)), 0 0 32px -8px rgb(var(--accent-human) / 0.45)',
+        'glow-status':
+          '0 0 0 1px rgb(var(--accent-status)), 0 0 32px -8px rgb(var(--accent-status) / 0.45)'
       },
       animation: {
         'typing-caret': 'caret 1s steps(2) infinite',

--- a/tests/unit/data-integrity.test.ts
+++ b/tests/unit/data-integrity.test.ts
@@ -31,7 +31,7 @@ describe('MetricSchema', () => {
     });
   });
 
-  it('rejects a metric with non-hex accent', () => {
+  it('rejects a metric with invalid accent token', () => {
     expect(() =>
       MetricSchema.parse({
         value: '99%',
@@ -39,7 +39,7 @@ describe('MetricSchema', () => {
         context: 'a real context',
         accent: 'orangish'
       })
-    ).toThrow(/hex/);
+    ).toThrow();
   });
 
   it('rejects a metric with too-short label', () => {
@@ -48,7 +48,7 @@ describe('MetricSchema', () => {
         value: '99%',
         label: 'short',
         context: 'a real context',
-        accent: '#ffb86c'
+        accent: 'impact'
       })
     ).toThrow(/≥10/);
   });
@@ -61,7 +61,7 @@ describe('MetricSchema', () => {
         context: 'a real context',
         methodology: 'Bootstrapped over weekly cohorts',
         confidenceBound: { lower: '68%', upper: '75%', note: '95% CI' },
-        accent: '#ffb86c'
+        accent: 'impact'
       })
     ).not.toThrow();
   });
@@ -89,7 +89,7 @@ describe('ExperienceSchema', () => {
             value: '50%',
             label: 'a sufficiently long label here',
             context: 'a real context',
-            accent: '#ffb86c'
+            accent: 'impact'
           }
         ],
         techHighlights: ['Python'],
@@ -124,7 +124,7 @@ describe('ExperienceSchema', () => {
             value: '50%',
             label: 'a sufficiently long label',
             context: 'a real context',
-            accent: '#ffb86c'
+            accent: 'impact'
           }
         ],
         techHighlights: ['Python'],
@@ -150,7 +150,7 @@ describe('ProjectSchema', () => {
         domain: 'GenAI & Agentic Systems',
         repoUrl: 'not-a-url',
         tags: ['tag'],
-        accentColor: '#bd93f9',
+        accentColor: 'brand',
         featured: false
       })
     ).toThrow();
@@ -165,7 +165,7 @@ describe('ProjectSchema', () => {
         domain: 'GenAI & Agentic Systems',
         repoUrl: 'https://github.com/x/y',
         tags: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], // 9 > max 8
-        accentColor: '#bd93f9',
+        accentColor: 'brand',
         featured: false
       })
     ).toThrow();


### PR DESCRIPTION
## Summary
- Replace ~100 hardcoded Dracula hex values (`#bd93f9`, `#50fa7b`, etc.) across 20 files with semantic accent tokens that resolve to CSS custom properties
- Create `src/lib/accents.ts` utility module (`AccentToken` type + `accentVar()` helper) as the single source for accent token resolution
- Update Zod schemas from `HexColor` regex to `AccentToken` enum validation — data files now store token names like `'brand'`, `'infra'` instead of hex strings
- All inline styles, component defaults, SVG fills (RadarChart), glow shadows, typography tokens, and the dracula-rainbow gradient now adapt automatically when the theme switches
- The `::selection` color also adapts via `rgb(var(--bg-base))` instead of a hardcoded dark hex

**Not migrated:** The GitHub streak widget URL in `runtime.astro` retains hex values — those are query parameters for an external API (`streak-stats.demolab.com`) that requires hex input.

### Files changed (20)

| Layer | Files |
|-------|-------|
| Infrastructure | `global.css`, `tailwind.config.mjs`, `src/lib/accents.ts` (new) |
| Schema | `src/data/schemas.ts` |
| Data | `projects.ts`, `experiences.ts`, `stack.ts`, `metrics.ts` |
| Components | `BentoCard.astro`, `TechBadge.astro`, `StatusBeacon.astro`, `MetricCard.astro`, `RadarChart.svelte` |
| Pages | `index.astro`, `runtime.astro`, `notes/index.astro`, `ping.astro`, `architecture.astro`, `stack.astro` |
| Tests | `data-integrity.test.ts` |

## Test plan
- [x] `npx tsx scripts/validate-data.ts` — all typed data valid
- [x] `npx astro build` — 10 pages built, zero errors
- [x] `npx vitest run` — 19/19 tests pass (including updated accent token fixtures)
- [ ] Visual check: toggle theme and verify accent colors adapt on all pages
- [ ] Verify `prose` code/link colors use CSS vars in note pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)