### PR TITLE
docs(specs): v2 design spec + end-user accent picker RFC

### DIFF
--- a/specs/02_design.md
+++ b/specs/02_design.md
@@ -1,4 +1,3 @@
-
 # DESIGN_SPEC.md — v2 (Claude Design Variant)
 
 **Document Owner:** Staff Software Engineer / TPM
@@ -23,24 +22,24 @@ Identical positioning to [01_design.md §1.1](01_design.md): Surya Avala — Pri
 
 What changes here is **how** that thesis is expressed in the browser. Two parallel hero modes are now in scope:
 
-* **Safe · Bento** — the v1-faithful 4×N grid, expanded to 9 semantic nodes with sparklines and a build-computed "By the Numbers" card.
-* **Bold · Editorial** — an editorial typographic hero (clamp 48–108px italic gradient title), a flipping status board, a terminal-styled sidebar, a borderless 4-up KPI strip, and three section blocks below the fold.
+- **Safe · Bento** — the v1-faithful 4×N grid, expanded to 9 semantic nodes with sparklines and a build-computed "By the Numbers" card.
+- **Bold · Editorial** — an editorial typographic hero (clamp 48–108px italic gradient title), a flipping status board, a terminal-styled sidebar, a borderless 4-up KPI strip, and three section blocks below the fold.
 
 Both variants serve the same data, the same audiences, and the same eight-second scanning promise. The variant switch lives in a developer-facing **Tweaks panel** (§3.5) and is persisted to `localStorage`. Default is `safe` for first-time visitors.
 
 ### 1.2 Goals
 
-* **Visual parity with the handoff bundle.** The Astro implementation must match [specs/design/suryaavala-com/project/index.html](design/suryaavala-com/project/index.html) and its imports at the level of layout grids, token values, easing curves, hover transitions, and animation cadence. Recreate; do not reinterpret.
-* **Maximum performance** (Lighthouse 100/100, all four pillars), inherited from v1.
-* **Frictionless authoring** (Local MDX), inherited from v1.
-* **Identity-preserving theming** — six brand-accent swatches and a light/dark theme toggle. Both must persist across navigations and survive a hard reload.
+- **Visual parity with the handoff bundle.** The Astro implementation must match [specs/design/suryaavala-com/project/index.html](design/suryaavala-com/project/index.html) and its imports at the level of layout grids, token values, easing curves, hover transitions, and animation cadence. Recreate; do not reinterpret.
+- **Maximum performance** (Lighthouse 100/100, all four pillars), inherited from v1.
+- **Frictionless authoring** (Local MDX), inherited from v1.
+- **Identity-preserving theming** — six brand-accent swatches and a light/dark theme toggle. Both must persist across navigations and survive a hard reload.
 
 ### 1.3 Non-Goals
 
 Inherits all non-goals from [01_design.md §1.3](01_design.md). Additionally:
 
-* **NO design-system CSS framework lock-in.** The Claude design is hand-authored CSS with custom properties, `color-mix(in oklab, …)`, and OKLAB blends. Tailwind is retained for utility classes (§2.1), but the canonical visual contract is the token set in §3.1 — consumed via Tailwind's `theme.extend` and via per-component `<style>` blocks. Do not rewrite the Claude CSS into utility-only Tailwind; that loses the OKLAB blends and the named-pseudo cascades the bundle relies on.
-* **NO third hero variant.** Two variants only. If a third is requested, it gets its own RFC.
+- **NO design-system CSS framework lock-in.** The Claude design is hand-authored CSS with custom properties, `color-mix(in oklab, …)`, and OKLAB blends. Tailwind is retained for utility classes (§2.1), but the canonical visual contract is the token set in §3.1 — consumed via Tailwind's `theme.extend` and via per-component `<style>` blocks. Do not rewrite the Claude CSS into utility-only Tailwind; that loses the OKLAB blends and the named-pseudo cascades the bundle relies on.
+- **NO third hero variant.** Two variants only. If a third is requested, it gets its own RFC.
 
 ---
 
@@ -50,11 +49,11 @@ Inherits all non-goals from [01_design.md §1.3](01_design.md). Additionally:
 
 Identical to [01_design.md §2.1](01_design.md), with one styling-engine clarification:
 
-* **Core Framework (Routing & SSG):** `Astro` (v4+).
-* **Interactive Components (Islands):** `Svelte`.
-* **Styling Engine:** `Tailwind CSS` for utility classes, **layered over** a hand-authored token sheet (`/src/styles/tokens.css`) and per-component `<style>` blocks. Tokens from §3.1 are exposed both as CSS custom properties (for `color-mix`, OKLAB blends, gradient stops) and as Tailwind theme extensions (for `bg-brand`, `text-impact`, etc.). Per-component CSS — hero card, status board, KPI strip, terminal sidebar, contact modal, radar — is lifted verbatim from the handoff bundle and re-scoped to Astro components.
-* **Content Pipeline:** Local `MDX` (Markdown + embedded Svelte components).
-* **Package Manager:** `npm` with strict lockfile enforcement (`npm ci` in CI).
+- **Core Framework (Routing & SSG):** `Astro` (v4+).
+- **Interactive Components (Islands):** `Svelte`.
+- **Styling Engine:** `Tailwind CSS` for utility classes, **layered over** a hand-authored token sheet (`/src/styles/tokens.css`) and per-component `<style>` blocks. Tokens from §3.1 are exposed both as CSS custom properties (for `color-mix`, OKLAB blends, gradient stops) and as Tailwind theme extensions (for `bg-brand`, `text-impact`, etc.). Per-component CSS — hero card, status board, KPI strip, terminal sidebar, contact modal, radar — is lifted verbatim from the handoff bundle and re-scoped to Astro components.
+- **Content Pipeline:** Local `MDX` (Markdown + embedded Svelte components).
+- **Package Manager:** `npm` with strict lockfile enforcement (`npm ci` in CI).
 
 ### 2.2 Data Flow & Infrastructure
 
@@ -73,74 +72,73 @@ Authoritative token sheet — copy verbatim into `/src/styles/tokens.css`. These
 ```css
 :root {
   /* Type */
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, "SF Mono", Menlo, monospace;
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, 'SF Mono', Menlo, monospace;
 
   /* Dark — primary theme */
-  --bg:        #0d1117;   /* GitHub Dark base */
-  --bg-2:      #11161d;
-  --surface:   #161b22;
+  --bg: #0d1117; /* GitHub Dark base */
+  --bg-2: #11161d;
+  --surface: #161b22;
   --surface-2: #1b2129;
   --surface-3: #21262d;
-  --border:    #30363d;
+  --border: #30363d;
   --border-soft: #222830;
-  --text:      #f8f8f2;   /* Dracula foreground */
-  --text-2:    #c9d1d9;
+  --text: #f8f8f2; /* Dracula foreground */
+  --text-2: #c9d1d9;
   --text-muted: #7a8bc0;
   --text-faint: #4e5872;
 
   /* Dracula accents */
-  --brand:      #bd93f9;  /* purple */
-  --brand-body: #c4a0ff;  /* AA on dark for body-size purple */
-  --status:     #50fa7b;  /* green */
-  --infra:      #8be9fd;  /* cyan */
-  --impact:     #ffb86c;  /* orange */
-  --human:      #ff79c6;  /* pink */
-  --stack:      #f1fa8c;  /* yellow */
-  --danger:     #ff5555;  /* red */
+  --brand: #bd93f9; /* purple */
+  --brand-body: #c4a0ff; /* AA on dark for body-size purple */
+  --status: #50fa7b; /* green */
+  --infra: #8be9fd; /* cyan */
+  --impact: #ffb86c; /* orange */
+  --human: #ff79c6; /* pink */
+  --stack: #f1fa8c; /* yellow */
+  --danger: #ff5555; /* red */
 
   /* Radii */
   --radius-sm: 6px;
-  --radius:    10px;
+  --radius: 10px;
   --radius-lg: 14px;
 
   /* Motion */
   --easing: cubic-bezier(0.2, 0.7, 0.2, 1);
-  --shadow-glow: 0 0 0 1px rgba(189, 147, 249, 0.12),
-                 0 24px 60px -30px rgba(189, 147, 249, 0.35);
+  --shadow-glow: 0 0 0 1px rgba(189, 147, 249, 0.12), 0 24px 60px -30px rgba(189, 147, 249, 0.35);
 }
 
 :root.light {
   /* WCAG AA-tuned light palette — DEEPER accents than v1's brightened variants */
-  --bg:        #f6f7f9;
-  --bg-2:      #eceff4;
-  --surface:   #ffffff;
+  --bg: #f6f7f9;
+  --bg-2: #eceff4;
+  --surface: #ffffff;
   --surface-2: #f1f3f7;
   --surface-3: #e6eaf0;
-  --border:      #c8d0db;   /* stronger separation against #fff surfaces */
+  --border: #c8d0db; /* stronger separation against #fff surfaces */
   --border-soft: #dde2ea;
-  --text:        #0b1220;
-  --text-2:      #1f2937;
-  --text-muted:  #3b475a;   /* AA ≥7:1 on bg/surface */
-  --text-faint:  #6b7280;   /* AA ≥4.5:1 on surface */
+  --text: #0b1220;
+  --text-2: #1f2937;
+  --text-muted: #3b475a; /* AA ≥7:1 on bg/surface */
+  --text-faint: #6b7280; /* AA ≥4.5:1 on surface */
 
-  --brand:      #5b21b6;    /* deeper purple — AA on white */
+  --brand: #5b21b6; /* deeper purple — AA on white */
   --brand-body: #5b21b6;
-  --status:     #0f6b34;
-  --infra:      #075e7a;
-  --impact:     #9a3412;
-  --human:      #9d174d;
-  --stack:      #854d0e;
-  --danger:     #9b1c1c;
+  --status: #0f6b34;
+  --infra: #075e7a;
+  --impact: #9a3412;
+  --human: #9d174d;
+  --stack: #854d0e;
+  --danger: #9b1c1c;
 
-  --shadow-glow: 0 0 0 1px rgba(91, 33, 182, 0.14),
-                 0 20px 40px -20px rgba(91, 33, 182, 0.28);
+  --shadow-glow: 0 0 0 1px rgba(91, 33, 182, 0.14), 0 20px 40px -20px rgba(91, 33, 182, 0.28);
 }
 ```
 
 **Typography deltas vs v1:**
-* Mono family is **`JetBrains Mono`** (not Fira Code). Fira Code remains as a fallback only.
-* Inter is loaded with weights `400;500;600;700` and the OpenType features `cv02 cv03 cv04 cv11 ss01` enabled at the `<html>` level (matching the Claude bundle's `font-feature-settings`).
+
+- Mono family is **`JetBrains Mono`** (not Fira Code). Fira Code remains as a fallback only.
+- Inter is loaded with weights `400;500;600;700` and the OpenType features `cv02 cv03 cv04 cv11 ss01` enabled at the `<html>` level (matching the Claude bundle's `font-feature-settings`).
 
 **Background ambient layer:** A fixed full-viewport CSS grid pattern (`64px × 64px` lines at `color-mix(in oklab, var(--border) 50%, transparent)`) masked with a top-anchored radial fade. Opacity `0.35` in dark mode, `0.55` in light mode. Painted via `body::before`. Pure CSS, zero JS, zero asset weight.
 
@@ -150,36 +148,36 @@ Authoritative token sheet — copy verbatim into `/src/styles/tokens.css`. These
 
 Components below are the Claude vocabulary. Each is implemented as either a server-rendered Astro component (no JS) or a Svelte Island (interactive). Pixel parity targets the noted source files in [specs/design/suryaavala-com/project/](design/suryaavala-com/project/).
 
-| Component | Astro / Svelte | Source CSS | Notes |
-|---|---|---|---|
-| **Glass Nav** (sticky, `backdrop-filter: blur(16px) saturate(160%)`) | Astro | `styles.css` `.nav` | Mono `~/suryaavala.com` brand, slash-prefixed mono links (`/architecture`, `/runtime`, …), gradient underline `linear-gradient(90deg, var(--brand), var(--infra))` on `.active`. Hides `.cta-btn` below 1024px (status board carries it on mobile). |
-| **Brand Mark Logo** | Astro | `.brand-mark .logo` | 28×28 rounded square, `linear-gradient(135deg, var(--brand), var(--human))`, bg-coloured "SA" glyph. |
-| **Theme Toggle** | Svelte | `styles.css` `.icon-btn` | Sun/moon SVG swap. Persists to `localStorage["sa-theme"]`. Inline pre-FOUC script applies the saved class on `<html>` before paint (lift verbatim from [index.html:15-21](design/suryaavala-com/project/index.html)). |
-| **CTA Pill** ("Open to Work") | Astro | `.cta-btn` | Border + bg `var(--surface)`, 8px pulsing dot in `var(--status)` with 2s `ease-in-out` ring animation. |
-| **Bento Grid (Safe variant)** | Astro | `home-safe.css` `.bento` | `grid-template-columns: repeat(4, minmax(0,1fr))`, `grid-auto-rows: minmax(200px, auto)`, `gap: 16px`. Per-card spans listed in §4.1.A. |
-| **Hero Card (Safe)** | Astro + Svelte typing island | `.hero-card`, `.hero-name`, `.hero-type`, `.hero-tagline` | Two radial gradients overlay `var(--surface)`. Name with gradient-clipped first word (`background-clip: text`, `linear-gradient(90deg, var(--brand), var(--human))`). Italic mono tagline left-bordered with `2px solid var(--brand)`. |
-| **Typing Hero** | Svelte Island | `.hero-type .cursor` | Cycles `D.hero.phrases`. `Fira Code → JetBrains Mono`, color `var(--brand-body)`. Char-add cadence ~55ms, char-delete ~30ms, end-of-word pause 1400ms. Cursor: 2px-wide block with `blink 1s steps(2)`. |
-| **Metric (Bento Impact card)** | Astro + Svelte count-up island | `.metric`, `.metric-value`, `.spark` | 32px mono value in `var(--impact)` with mini-arrow `direction`, descriptive `label`, cyan `metric-ctx` (sourced from `metric.context`), faint `metric-method` (sourced from `metric.method`), 22px-tall inline SVG sparkline (`stroke: var(--impact)`, `opacity: 0.55`). Sparkline path computed from `metric.spark: number[]` via §3.6 helper. Count-up triggered by `IntersectionObserver` on first scroll-into-view; `aria-live="polite"` for SR. |
-| **Status Beacon** | Astro | `.status-beacon` | 10px green dot, 3px ring, 2s `pulse` keyframe. |
-| **Status Board (Bold variant)** | Svelte Island | `home-bold.css` `.status-board` | Horizontal bar: pulsing LED · `Open to Work` · location flipper · separator · role flipper · primary CTA. Two flippers run independently — location (4.2s interval, 1.8s delay), role (3.2s interval, 1.2s delay). Items rotate via `transform: translateY(60%) rotateX(-70deg) → translateY(0) rotateX(0)` with 0.42s `cubic-bezier(0.5, 0, 0.2, 1)`. The CTA opens the Contact Modal (§3.2 row below). All animations gated by `prefers-reduced-motion`. |
-| **Editorial Title (Bold)** | Astro | `.bold-title` | `font-family: var(--font-sans)`, `font-size: clamp(48px, 8vw, 108px)`, weight 500, `letter-spacing: -0.04em`, `line-height: 0.92`. Italicised `<em>` segment uses gradient-clipped text `linear-gradient(90deg, var(--brand) 0%, var(--human) 55%, var(--impact) 100%)`. Mono sub-headline at `0.35em`. |
-| **Terminal Sidebar (Bold hero)** | Astro | `.terminal`, `.term-bar`, `.term-body` | Card with macOS traffic-light dots, mono prompt lines, JSON-syntax-coloured output (`.k` cyan / `.s` yellow / `.v` orange). Static — no JS. |
-| **KPI Strip (Bold)** | Astro + count-up | `.kpi-strip`, `.kpi` | Borderless 4-up `display: grid` with internal soft borders. Big mono number with directional arrow + unit, label, ctx. Per-cell accent class `k-impact`/`k-status`/`k-infra`/`k-human` colours the number. |
-| **Featured / Latest Badge** | Astro | `.card-badge.featured`, `.card-badge.latest` | Absolute-positioned mono chip top-right; orange for Featured, cyan for Latest. |
-| **Card with Accent Hover** | Astro | `.card`, `.card--brand`, `.card--status`, … | Each card variant lifts a colour-mix shadow + border on hover: `box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 30%, transparent), 0 20px 40px -20px color-mix(in oklab, var(--accent) 45%, transparent)`. |
-| **Pill** (`.pill` + `.pill-{accent}`) | Astro | `styles.css` `.pill` | `font-family: var(--font-mono)`, 11.5px, color-mix accent border. Used everywhere tags appear. |
-| **Rainbow HR** | Astro | `.rainbow-hr` | 2px-tall `<hr>` with full Dracula gradient `linear-gradient(90deg, var(--danger), var(--impact), var(--stack), var(--status), var(--infra), var(--brand), var(--human))`, opacity 0.7. Used inside the Safe hero card. |
-| **Mission Slab (Bold §3)** | Astro | `home-bold.css` `.mission-slab` | Pink-tinted gradient surface, two-column layout: oversized mono glyph quote on the left, italic blockquote + mono `<cite>` on the right. Collapses to one column ≤ 700px. |
-| **Section Header** (`.sec-head`) | Astro | `home-bold.css` `.sec-head` | Numbered eyebrow (`01 /`, `02 /`, `03 /`) in mono muted colour, 22–30px clamp section title, dashed soft underline. Used between Bold-variant sections. |
-| **Timeline Entry** (`/runtime`) | Astro | `pages.css` `.timeline`, `.tl-entry` | Vertical gradient line `linear-gradient(to bottom, var(--brand), var(--infra), var(--human))` at 0.5 opacity. Per-entry node colour driven by `data-accent`. 4-up metric grid per role with dashed-bordered detail row. Two-column tech / leadership lists. |
-| **Project Card** (`/architecture`) | Astro | `.proj` | Mono title, hover lifts 2px and switches border to `var(--brand)`, accent-coloured pill row. |
-| **Stack Category** + **Radar Chart** (`/stack`) | Astro + Svelte radar island | `pages.css` `.stack-page`, `.radar-wrap` | Two-column desktop layout `1.1fr 1fr`. Categories left, sticky radar right. Radar = inline SVG (§3.4) with hover tooltips bound to dot circles. |
-| **Note Row** (`/notes`) | Astro | `.note` | 3-column grid (date · body · `read →`). Hover lifts border to `var(--brand)`, translates `+2px` on X. Mono `∫ KaTeX` tag if `frontmatter.requiresMath`. |
-| **Shield Row + Contact Card** (`/ping`) | Astro | `pages.css` `.shield`, `.contact` | README-style shields in a wrap row at hero foot; below, a 3-up grid of cards with channel-specific `c-{accent}` modifier — left 3px accent ribbon, accent-tinted handle, channel-coloured hover glow. SVG glyphs (GitHub, LinkedIn, Gmail, Firefox, Coffee, Sponsor) lifted from [app.js:516-528](design/suryaavala-com/project/app.js). |
-| **Traceroute Block** (`/ping` foot) | Astro | `.ping-fun` | Dashed-border block with diagonal `repeating-linear-gradient` brand-tinted background. Three mono rows: `1 github.com … 1.2ms`, `2 linkedin.com … 2.4ms`, `3 inbox … ~24h`. Editorial easter egg, zero JS. |
-| **Contact Modal** | Svelte Island | `home-bold.css` `.contact-modal`, `.cm-*` | Centred 580px panel with backdrop blur + brand-tinted radial wash. Pop-in `cm-pop-in 0.28s` keyframe. Six rows, each: hotkey chip (G/L/E/W/C/S) · channel name + handle · SLA + action arrow. Esc closes. Hotkeys jump to channel. Focus is moved to first row on open and restored on close. `body.is-modal-open` locks scroll. |
-| **Tweaks Panel** | Svelte Island | `styles.css` `.tweaks` | Fixed bottom-right, 260px wide. Two controls: **Homepage variant** segmented toggle (Safe · Bold), **Brand accent** swatch row (Purple / Cyan / Green / Orange / Pink). Persists to `localStorage["sa-home-variant"]` and `localStorage["sa-accent"]`. Visible only when `parent.postMessage({type: "__activate_edit_mode"})` is received from the dev harness — production users see no tweaks panel. (See §3.5.) |
-| **Page Transition** | CSS | `styles.css` `.page` | `page-in 0.45s var(--easing) both`: from `opacity:0; translateY(8px); filter: blur(4px)` → `opacity:1; translateY(0); filter: blur(0)`. Re-triggered after each route change by removing/re-adding the class and forcing a reflow (`void container.offsetWidth`). |
+| Component                                                            | Astro / Svelte                 | Source CSS                                                | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| -------------------------------------------------------------------- | ------------------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Glass Nav** (sticky, `backdrop-filter: blur(16px) saturate(160%)`) | Astro                          | `styles.css` `.nav`                                       | Mono `~/suryaavala.com` brand, slash-prefixed mono links (`/architecture`, `/runtime`, …), gradient underline `linear-gradient(90deg, var(--brand), var(--infra))` on `.active`. Hides `.cta-btn` below 1024px (status board carries it on mobile).                                                                                                                                                                                                        |
+| **Brand Mark Logo**                                                  | Astro                          | `.brand-mark .logo`                                       | 28×28 rounded square, `linear-gradient(135deg, var(--brand), var(--human))`, bg-coloured "SA" glyph.                                                                                                                                                                                                                                                                                                                                                       |
+| **Theme Toggle**                                                     | Svelte                         | `styles.css` `.icon-btn`                                  | Sun/moon SVG swap. Persists to `localStorage["sa-theme"]`. Inline pre-FOUC script applies the saved class on `<html>` before paint (lift verbatim from [index.html:15-21](design/suryaavala-com/project/index.html)).                                                                                                                                                                                                                                      |
+| **CTA Pill** ("Open to Work")                                        | Astro                          | `.cta-btn`                                                | Border + bg `var(--surface)`, 8px pulsing dot in `var(--status)` with 2s `ease-in-out` ring animation.                                                                                                                                                                                                                                                                                                                                                     |
+| **Bento Grid (Safe variant)**                                        | Astro                          | `home-safe.css` `.bento`                                  | `grid-template-columns: repeat(4, minmax(0,1fr))`, `grid-auto-rows: minmax(200px, auto)`, `gap: 16px`. Per-card spans listed in §4.1.A.                                                                                                                                                                                                                                                                                                                    |
+| **Hero Card (Safe)**                                                 | Astro + Svelte typing island   | `.hero-card`, `.hero-name`, `.hero-type`, `.hero-tagline` | Two radial gradients overlay `var(--surface)`. Name with gradient-clipped first word (`background-clip: text`, `linear-gradient(90deg, var(--brand), var(--human))`). Italic mono tagline left-bordered with `2px solid var(--brand)`.                                                                                                                                                                                                                     |
+| **Typing Hero**                                                      | Svelte Island                  | `.hero-type .cursor`                                      | Cycles `D.hero.phrases`. `Fira Code → JetBrains Mono`, color `var(--brand-body)`. Char-add cadence ~55ms, char-delete ~30ms, end-of-word pause 1400ms. Cursor: 2px-wide block with `blink 1s steps(2)`.                                                                                                                                                                                                                                                    |
+| **Metric (Bento Impact card)**                                       | Astro + Svelte count-up island | `.metric`, `.metric-value`, `.spark`                      | 32px mono value in `var(--impact)` with mini-arrow `direction`, descriptive `label`, cyan `metric-ctx` (sourced from `metric.context`), faint `metric-method` (sourced from `metric.method`), 22px-tall inline SVG sparkline (`stroke: var(--impact)`, `opacity: 0.55`). Sparkline path computed from `metric.spark: number[]` via §3.6 helper. Count-up triggered by `IntersectionObserver` on first scroll-into-view; `aria-live="polite"` for SR.       |
+| **Status Beacon**                                                    | Astro                          | `.status-beacon`                                          | 10px green dot, 3px ring, 2s `pulse` keyframe.                                                                                                                                                                                                                                                                                                                                                                                                             |
+| **Status Board (Bold variant)**                                      | Svelte Island                  | `home-bold.css` `.status-board`                           | Horizontal bar: pulsing LED · `Open to Work` · location flipper · separator · role flipper · primary CTA. Two flippers run independently — location (4.2s interval, 1.8s delay), role (3.2s interval, 1.2s delay). Items rotate via `transform: translateY(60%) rotateX(-70deg) → translateY(0) rotateX(0)` with 0.42s `cubic-bezier(0.5, 0, 0.2, 1)`. The CTA opens the Contact Modal (§3.2 row below). All animations gated by `prefers-reduced-motion`. |
+| **Editorial Title (Bold)**                                           | Astro                          | `.bold-title`                                             | `font-family: var(--font-sans)`, `font-size: clamp(48px, 8vw, 108px)`, weight 500, `letter-spacing: -0.04em`, `line-height: 0.92`. Italicised `<em>` segment uses gradient-clipped text `linear-gradient(90deg, var(--brand) 0%, var(--human) 55%, var(--impact) 100%)`. Mono sub-headline at `0.35em`.                                                                                                                                                    |
+| **Terminal Sidebar (Bold hero)**                                     | Astro                          | `.terminal`, `.term-bar`, `.term-body`                    | Card with macOS traffic-light dots, mono prompt lines, JSON-syntax-coloured output (`.k` cyan / `.s` yellow / `.v` orange). Static — no JS.                                                                                                                                                                                                                                                                                                                |
+| **KPI Strip (Bold)**                                                 | Astro + count-up               | `.kpi-strip`, `.kpi`                                      | Borderless 4-up `display: grid` with internal soft borders. Big mono number with directional arrow + unit, label, ctx. Per-cell accent class `k-impact`/`k-status`/`k-infra`/`k-human` colours the number.                                                                                                                                                                                                                                                 |
+| **Featured / Latest Badge**                                          | Astro                          | `.card-badge.featured`, `.card-badge.latest`              | Absolute-positioned mono chip top-right; orange for Featured, cyan for Latest.                                                                                                                                                                                                                                                                                                                                                                             |
+| **Card with Accent Hover**                                           | Astro                          | `.card`, `.card--brand`, `.card--status`, …               | Each card variant lifts a colour-mix shadow + border on hover: `box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 30%, transparent), 0 20px 40px -20px color-mix(in oklab, var(--accent) 45%, transparent)`.                                                                                                                                                                                                                                         |
+| **Pill** (`.pill` + `.pill-{accent}`)                                | Astro                          | `styles.css` `.pill`                                      | `font-family: var(--font-mono)`, 11.5px, color-mix accent border. Used everywhere tags appear.                                                                                                                                                                                                                                                                                                                                                             |
+| **Rainbow HR**                                                       | Astro                          | `.rainbow-hr`                                             | 2px-tall `<hr>` with full Dracula gradient `linear-gradient(90deg, var(--danger), var(--impact), var(--stack), var(--status), var(--infra), var(--brand), var(--human))`, opacity 0.7. Used inside the Safe hero card.                                                                                                                                                                                                                                     |
+| **Mission Slab (Bold §3)**                                           | Astro                          | `home-bold.css` `.mission-slab`                           | Pink-tinted gradient surface, two-column layout: oversized mono glyph quote on the left, italic blockquote + mono `<cite>` on the right. Collapses to one column ≤ 700px.                                                                                                                                                                                                                                                                                  |
+| **Section Header** (`.sec-head`)                                     | Astro                          | `home-bold.css` `.sec-head`                               | Numbered eyebrow (`01 /`, `02 /`, `03 /`) in mono muted colour, 22–30px clamp section title, dashed soft underline. Used between Bold-variant sections.                                                                                                                                                                                                                                                                                                    |
+| **Timeline Entry** (`/runtime`)                                      | Astro                          | `pages.css` `.timeline`, `.tl-entry`                      | Vertical gradient line `linear-gradient(to bottom, var(--brand), var(--infra), var(--human))` at 0.5 opacity. Per-entry node colour driven by `data-accent`. 4-up metric grid per role with dashed-bordered detail row. Two-column tech / leadership lists.                                                                                                                                                                                                |
+| **Project Card** (`/architecture`)                                   | Astro                          | `.proj`                                                   | Mono title, hover lifts 2px and switches border to `var(--brand)`, accent-coloured pill row.                                                                                                                                                                                                                                                                                                                                                               |
+| **Stack Category** + **Radar Chart** (`/stack`)                      | Astro + Svelte radar island    | `pages.css` `.stack-page`, `.radar-wrap`                  | Two-column desktop layout `1.1fr 1fr`. Categories left, sticky radar right. Radar = inline SVG (§3.4) with hover tooltips bound to dot circles.                                                                                                                                                                                                                                                                                                            |
+| **Note Row** (`/notes`)                                              | Astro                          | `.note`                                                   | 3-column grid (date · body · `read →`). Hover lifts border to `var(--brand)`, translates `+2px` on X. Mono `∫ KaTeX` tag if `frontmatter.requiresMath`.                                                                                                                                                                                                                                                                                                    |
+| **Shield Row + Contact Card** (`/ping`)                              | Astro                          | `pages.css` `.shield`, `.contact`                         | README-style shields in a wrap row at hero foot; below, a 3-up grid of cards with channel-specific `c-{accent}` modifier — left 3px accent ribbon, accent-tinted handle, channel-coloured hover glow. SVG glyphs (GitHub, LinkedIn, Gmail, Firefox, Coffee, Sponsor) lifted from [app.js:516-528](design/suryaavala-com/project/app.js).                                                                                                                   |
+| **Traceroute Block** (`/ping` foot)                                  | Astro                          | `.ping-fun`                                               | Dashed-border block with diagonal `repeating-linear-gradient` brand-tinted background. Three mono rows: `1 github.com … 1.2ms`, `2 linkedin.com … 2.4ms`, `3 inbox … ~24h`. Editorial easter egg, zero JS.                                                                                                                                                                                                                                                 |
+| **Contact Modal**                                                    | Svelte Island                  | `home-bold.css` `.contact-modal`, `.cm-*`                 | Centred 580px panel with backdrop blur + brand-tinted radial wash. Pop-in `cm-pop-in 0.28s` keyframe. Six rows, each: hotkey chip (G/L/E/W/C/S) · channel name + handle · SLA + action arrow. Esc closes. Hotkeys jump to channel. Focus is moved to first row on open and restored on close. `body.is-modal-open` locks scroll.                                                                                                                           |
+| **Tweaks Panel**                                                     | Svelte Island                  | `styles.css` `.tweaks`                                    | Fixed bottom-right, 260px wide. Two controls: **Homepage variant** segmented toggle (Safe · Bold), **Brand accent** swatch row (Purple / Cyan / Green / Orange / Pink). Persists to `localStorage["sa-home-variant"]` and `localStorage["sa-accent"]`. Visible only when `parent.postMessage({type: "__activate_edit_mode"})` is received from the dev harness — production users see no tweaks panel. (See §3.5.)                                         |
+| **Page Transition**                                                  | CSS                            | `styles.css` `.page`                                      | `page-in 0.45s var(--easing) both`: from `opacity:0; translateY(8px); filter: blur(4px)` → `opacity:1; translateY(0); filter: blur(0)`. Re-triggered after each route change by removing/re-adding the class and forcing a reflow (`void container.offsetWidth`).                                                                                                                                                                                          |
 
 ### 3.3 Site Map (Multi-Page Routing)
 
@@ -200,13 +198,13 @@ The Claude bundle uses an SPA hash router for prototyping (`location.hash`, `ren
 
 Located on `/stack`, sticky in the right column at desktop ≥1000px. Identical mathematical shape to [01_design.md §4.4](01_design.md), but with the Claude colour treatment:
 
-* `viewBox="0 0 340 340"`, radius `120`, centred at `(170, 170)`.
-* Five concentric rings at `pct ∈ {20, 40, 60, 80, 100}`, stroked `var(--border-soft)` with `opacity: 0.6 - i*0.08`.
-* Axis lines stroked `var(--border)`.
-* Filled data polygon: `fill="var(--brand)"` at `fill-opacity="0.28"`, `stroke="var(--brand)"` `stroke-width="1.8"`, `stroke-linejoin="round"`.
-* Per-axis dot: `circle r="4.5"` filled `var(--stack)` (yellow), stroked `var(--bg)` 2px to punch out from the polygon.
-* Axis labels: `<text fill="var(--infra)" font-family="var(--font-mono)" font-size="10">`, anchored `start | end | middle` based on `Math.cos(a)` quadrant.
-* Hover tooltip: floats inside `#radar-container`, mono 11.5px, brand-bordered, displays `<b>{label}</b> <span class="score">{score}/100</span> <br>{method}` (the `method` field — see §6.x note on the v1→v2 field rename). Position tracked via `mouseenter` + `mousemove` listeners on each dot.
+- `viewBox="0 0 340 340"`, radius `120`, centred at `(170, 170)`.
+- Five concentric rings at `pct ∈ {20, 40, 60, 80, 100}`, stroked `var(--border-soft)` with `opacity: 0.6 - i*0.08`.
+- Axis lines stroked `var(--border)`.
+- Filled data polygon: `fill="var(--brand)"` at `fill-opacity="0.28"`, `stroke="var(--brand)"` `stroke-width="1.8"`, `stroke-linejoin="round"`.
+- Per-axis dot: `circle r="4.5"` filled `var(--stack)` (yellow), stroked `var(--bg)` 2px to punch out from the polygon.
+- Axis labels: `<text fill="var(--infra)" font-family="var(--font-mono)" font-size="10">`, anchored `start | end | middle` based on `Math.cos(a)` quadrant.
+- Hover tooltip: floats inside `#radar-container`, mono 11.5px, brand-bordered, displays `<b>{label}</b> <span class="score">{score}/100</span> <br>{method}` (the `method` field — see §6.x note on the v1→v2 field rename). Position tracked via `mouseenter` + `mousemove` listeners on each dot.
 
 Reference implementation in [app.js:453-489](design/suryaavala-com/project/app.js) (`radarSVG(axes)` and `initRadar()`). Self-assessment methodology footnote (§4.4) carries over unchanged.
 
@@ -218,13 +216,13 @@ The Tweaks panel is **a developer affordance**, not a user-facing feature. It mu
 2. **State-only persistence.** Selecting `Bold` variant writes `localStorage["sa-home-variant"] = "bold"`; on next page render, the home route reads this and renders the Bold template instead of Safe. Selecting an accent swatch writes `localStorage["sa-accent"]` and immediately mutates `--brand` and `--brand-body` on `:root.style`.
 3. **Five accent presets** with the following `(brand, brand-body)` pairs (lifted from [app.js:34-40](design/suryaavala-com/project/app.js)):
 
-   | Key      | `--brand`  | `--brand-body` |
-   |----------|------------|----------------|
-   | `purple` | `#bd93f9`  | `#c4a0ff`      |
-   | `cyan`   | `#8be9fd`  | `#b4f0ff`      |
-   | `green`  | `#50fa7b`  | `#7effa0`      |
-   | `orange` | `#ffb86c`  | `#ffce99`      |
-   | `pink`   | `#ff79c6`  | `#ffa2d6`      |
+   | Key      | `--brand` | `--brand-body` |
+   | -------- | --------- | -------------- |
+   | `purple` | `#bd93f9` | `#c4a0ff`      |
+   | `cyan`   | `#8be9fd` | `#b4f0ff`      |
+   | `green`  | `#50fa7b` | `#7effa0`      |
+   | `orange` | `#ffb86c` | `#ffce99`      |
+   | `pink`   | `#ff79c6` | `#ffa2d6`      |
 
 4. **Defaults** stored under `EDITMODE-BEGIN ... EDITMODE-END` markers in source (so the Claude editor can rewrite them): `{"variant": "safe", "accent": "purple"}`.
 
@@ -234,11 +232,11 @@ If the user wants an end-user-facing accent picker post-launch, it gets a separa
 
 Centralise in `/src/lib/`:
 
-* **`sparkPath(values, w=120, h=22)`** — returns an SVG `path d` string for a min-max-normalised polyline. Reference: [app.js:103-112](design/suryaavala-com/project/app.js).
-* **`animateCountUp(el, target, duration=1400)`** — `IntersectionObserver`-driven cubic ease-out, formatted decimals based on magnitude. Reference: [app.js:77-100](design/suryaavala-com/project/app.js).
-* **`startTyping(el, phrases)`** — typewriter effect with 55/30 ms cadence and 1400 ms pause. Reference: [app.js:56-74](design/suryaavala-com/project/app.js).
-* **`initRoleFlip()`** — manages flipboard rotation for the bold-hero status board. Reference: [app.js:633-665](design/suryaavala-com/project/app.js).
-* **`pingLogo(name)`** — returns one of the six channel SVG glyphs. Reference: [app.js:516-528](design/suryaavala-com/project/app.js).
+- **`sparkPath(values, w=120, h=22)`** — returns an SVG `path d` string for a min-max-normalised polyline. Reference: [app.js:103-112](design/suryaavala-com/project/app.js).
+- **`animateCountUp(el, target, duration=1400)`** — `IntersectionObserver`-driven cubic ease-out, formatted decimals based on magnitude. Reference: [app.js:77-100](design/suryaavala-com/project/app.js).
+- **`startTyping(el, phrases)`** — typewriter effect with 55/30 ms cadence and 1400 ms pause. Reference: [app.js:56-74](design/suryaavala-com/project/app.js).
+- **`initRoleFlip()`** — manages flipboard rotation for the bold-hero status board. Reference: [app.js:633-665](design/suryaavala-com/project/app.js).
+- **`pingLogo(name)`** — returns one of the six channel SVG glyphs. Reference: [app.js:516-528](design/suryaavala-com/project/app.js).
 
 Every animation listed above must be wrapped in a `@media (prefers-reduced-motion: reduce)` guard that disables transform/opacity transitions while still flipping state — never hide content from users with motion sensitivity.
 
@@ -252,7 +250,7 @@ The homepage is rendered by `pageHome()` which dispatches to `homeSafe()` or `ho
 
 #### 4.1.A — Safe Bento (default)
 
-The Bento grid is **9 semantic nodes** (one more than v1), arranged in a 4-column desktop grid that reflects signal hierarchy: enterprise platform work and quantified metrics get the largest spans. The new node — "By the Numbers" — surfaces *build-time computed* totals (number of distinct industries, number of roles, number of measured metrics, number of upstream PRs), giving the grid completeness without inventing claims.
+The Bento grid is **9 semantic nodes** (one more than v1), arranged in a 4-column desktop grid that reflects signal hierarchy: enterprise platform work and quantified metrics get the largest spans. The new node — "By the Numbers" — surfaces _build-time computed_ totals (number of distinct industries, number of roles, number of measured metrics, number of upstream PRs), giving the grid completeness without inventing claims.
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -270,17 +268,17 @@ The Bento grid is **9 semantic nodes** (one more than v1), arranged in a 4-colum
 └─────────────────────────────────────────────────┘
 ```
 
-| # | Card | Source | Span | Accent | Notes |
-|---|---|---|---|---|---|
-| 1 | **Hero** | `hero-card .hero` | `span 4` | brand | Mono `~/whoami → surya` prompt eyebrow, `<h1>` with gradient-clipped first word, typing line, italic mono tagline, hero-sub, industries row, stack-pill row, rainbow `<hr>` foot. |
-| 2 | **Impact Cluster** | `impact-card .impact` | `span 2 × span 2` | impact | 6 metrics in a 2-column inner grid. Each metric: count-up value + dir + unit, label, mono cyan `metric-ctx`, faint `metric-method`, 22px sparkline. |
-| 3 | **Status** | `status-card .status` | `span 1` | status | Beacon, primary copy, mono "last verified" footer, link to `/ping`. |
-| 4 | **By the Numbers** | `nums .numbers` | `span 1` | human | `<dl>` with `decade`, `industries shipped` (`new Set(D.experiences.map(e => e.industry)).size`), `shipped roles` (`D.experiences.length`), `measured outcomes` (`D.metrics.length`), `upstream PRs` (`D.upstream.length`). Foot: `computed at build · not a marketing claim`. |
-| 5 | **Agentic Highlight** | `agentic .feature-card` | `span 2` | infra | `Featured` badge. The featured project (`projects.find(p => p.badge === "Featured")` → `scaling-succotash`). Cyan eyebrow `⬢ Agentic · Prod`, mono mark `›`, infra pill row. |
-| 6 | **Infra Highlight** | `infra-hl .feature-card` | `span 1` | infra | `Latest` badge. The latest project (`projects.find(p => p.badge === "Latest")` → `traffic_counter`). |
-| 7 | **OSS Upstream** | `oss-card .oss` | `span 1` | status | Top-5 PRs from `D.upstream`, mono list, status-coloured arrows. Foot count: `5 merged PRs across MLOps + data infra`. |
-| 8 | **Leadership** | `lead` | `span 2` | impact | `⌘ Technical Leadership` eyebrow, `Staff+ signal` heading, RFC + ML Guild + Build vs Buy copy, hire/mentor quote. |
-| 9 | **Beyond Code** | `beyond` | `span 2` | human | `♁ Beyond Code` eyebrow, `Equitable outcomes` heading, mission line including `🥐 Pastry Enthusiast`. |
+| #   | Card                  | Source                   | Span              | Accent | Notes                                                                                                                                                                                                                                                                         |
+| --- | --------------------- | ------------------------ | ----------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Hero**              | `hero-card .hero`        | `span 4`          | brand  | Mono `~/whoami → surya` prompt eyebrow, `<h1>` with gradient-clipped first word, typing line, italic mono tagline, hero-sub, industries row, stack-pill row, rainbow `<hr>` foot.                                                                                             |
+| 2   | **Impact Cluster**    | `impact-card .impact`    | `span 2 × span 2` | impact | 6 metrics in a 2-column inner grid. Each metric: count-up value + dir + unit, label, mono cyan `metric-ctx`, faint `metric-method`, 22px sparkline.                                                                                                                           |
+| 3   | **Status**            | `status-card .status`    | `span 1`          | status | Beacon, primary copy, mono "last verified" footer, link to `/ping`.                                                                                                                                                                                                           |
+| 4   | **By the Numbers**    | `nums .numbers`          | `span 1`          | human  | `<dl>` with `decade`, `industries shipped` (`new Set(D.experiences.map(e => e.industry)).size`), `shipped roles` (`D.experiences.length`), `measured outcomes` (`D.metrics.length`), `upstream PRs` (`D.upstream.length`). Foot: `computed at build · not a marketing claim`. |
+| 5   | **Agentic Highlight** | `agentic .feature-card`  | `span 2`          | infra  | `Featured` badge. The featured project (`projects.find(p => p.badge === "Featured")` → `scaling-succotash`). Cyan eyebrow `⬢ Agentic · Prod`, mono mark `›`, infra pill row.                                                                                                  |
+| 6   | **Infra Highlight**   | `infra-hl .feature-card` | `span 1`          | infra  | `Latest` badge. The latest project (`projects.find(p => p.badge === "Latest")` → `traffic_counter`).                                                                                                                                                                          |
+| 7   | **OSS Upstream**      | `oss-card .oss`          | `span 1`          | status | Top-5 PRs from `D.upstream`, mono list, status-coloured arrows. Foot count: `5 merged PRs across MLOps + data infra`.                                                                                                                                                         |
+| 8   | **Leadership**        | `lead`                   | `span 2`          | impact | `⌘ Technical Leadership` eyebrow, `Staff+ signal` heading, RFC + ML Guild + Build vs Buy copy, hire/mentor quote.                                                                                                                                                             |
+| 9   | **Beyond Code**       | `beyond`                 | `span 2`          | human  | `♁ Beyond Code` eyebrow, `Equitable outcomes` heading, mission line including `🥐 Pastry Enthusiast`.                                                                                                                                                                         |
 
 Reference: [app.js:119-215](design/suryaavala-com/project/app.js) (`homeSafe()`).
 
@@ -310,27 +308,27 @@ Reference: [app.js:119-215](design/suryaavala-com/project/app.js) (`homeSafe()`)
 §03 Beyond code      [mission-slab]
 ```
 
-* **Hero grid:** `1.6fr 1fr` two-column, 48px gap, 48px top / 64px bottom padding. Collapses to single column ≤1000px.
-* **Status Board** (top-left of left column): described in §3.2; takes `bold-meta` slot.
-* **Bold Title:** `clamp(48px, 8vw, 108px)`, weight 500, italic gradient `<em>`, mono `<span class="sub">` sub-line at `0.35em`.
-* **Bold Lede:** 19px, max-width 620px, `text-wrap: pretty`. Bold inline strongs land in `var(--text)`.
-* **CTAs:** `.btn-primary` (filled brand bg, bg-coloured text) → `/architecture`; `.btn-ghost` → `/ping`.
-* **Terminal Sidebar:** macOS chrome (red/yellow/green dots), mono content, three command blocks with JSON-coloured output (`whoami --verbose`, `cat impact.json | jq .top`, blinking prompt).
-* **KPI Strip:** Borderless 4-up `grid-template-columns: repeat(4, 1fr)` inside a single bordered card. Internal soft borders `border-right: 1px solid var(--border-soft)`. Picks `D.metrics[0..3]` and assigns accents `[impact, status, infra, human]` in order. Below 900px: 2 columns. Below 540px: 1 column.
-* **Sections (`§01–§03`):** numbered `sec-head` titles, dashed soft underline, content row beneath:
-  * **§01 Featured work** — 2:1 grid (featured | latest), reusing `.feature-card`.
-  * **§02 Upstream signal** — vertical list of 5 `.oss-row` rows, mono, status-coloured PR numbers.
-  * **§03 Beyond code** — `.mission-slab`: pink-tinted gradient card with oversized mono glyph quote on the left, italic blockquote + uppercase mono `<cite>` on the right.
+- **Hero grid:** `1.6fr 1fr` two-column, 48px gap, 48px top / 64px bottom padding. Collapses to single column ≤1000px.
+- **Status Board** (top-left of left column): described in §3.2; takes `bold-meta` slot.
+- **Bold Title:** `clamp(48px, 8vw, 108px)`, weight 500, italic gradient `<em>`, mono `<span class="sub">` sub-line at `0.35em`.
+- **Bold Lede:** 19px, max-width 620px, `text-wrap: pretty`. Bold inline strongs land in `var(--text)`.
+- **CTAs:** `.btn-primary` (filled brand bg, bg-coloured text) → `/architecture`; `.btn-ghost` → `/ping`.
+- **Terminal Sidebar:** macOS chrome (red/yellow/green dots), mono content, three command blocks with JSON-coloured output (`whoami --verbose`, `cat impact.json | jq .top`, blinking prompt).
+- **KPI Strip:** Borderless 4-up `grid-template-columns: repeat(4, 1fr)` inside a single bordered card. Internal soft borders `border-right: 1px solid var(--border-soft)`. Picks `D.metrics[0..3]` and assigns accents `[impact, status, infra, human]` in order. Below 900px: 2 columns. Below 540px: 1 column.
+- **Sections (`§01–§03`):** numbered `sec-head` titles, dashed soft underline, content row beneath:
+  - **§01 Featured work** — 2:1 grid (featured | latest), reusing `.feature-card`.
+  - **§02 Upstream signal** — vertical list of 5 `.oss-row` rows, mono, status-coloured PR numbers.
+  - **§03 Beyond code** — `.mission-slab`: pink-tinted gradient card with oversized mono glyph quote on the left, italic blockquote + uppercase mono `<cite>` on the right.
 
 Reference: [app.js:217-351](design/suryaavala-com/project/app.js) (`homeBold()`).
 
 ### 4.2 Architecture (`/architecture`)
 
-* `page-head` with mono `/architecture` eyebrow, `<h1>` with brand-coloured `<span class="accent">` for "architectural domain".
-* Projects grouped by `Project.domain`, rendered as `.proj` cards in a 3-column grid (2 col ≤1000px, 1 col ≤680px).
-* OSS section pinned at `#oss` anchor with status-coloured heading and 5 `.oss-row` entries linking to GitHub PRs in new tabs.
-* Domain order (deterministic): `GenAI & Agentic Systems → Systems & Infrastructure → ML & Data Science → Data Engineering & Tooling → Enterprise ML & Document Intelligence`.
-* Reference: [app.js:353-389](design/suryaavala-com/project/app.js).
+- `page-head` with mono `/architecture` eyebrow, `<h1>` with brand-coloured `<span class="accent">` for "architectural domain".
+- Projects grouped by `Project.domain`, rendered as `.proj` cards in a 3-column grid (2 col ≤1000px, 1 col ≤680px).
+- OSS section pinned at `#oss` anchor with status-coloured heading and 5 `.oss-row` entries linking to GitHub PRs in new tabs.
+- Domain order (deterministic): `GenAI & Agentic Systems → Systems & Infrastructure → ML & Data Science → Data Engineering & Tooling → Enterprise ML & Document Intelligence`.
+- Reference: [app.js:353-389](design/suryaavala-com/project/app.js).
 
 The "Full Catalogue" `<details>` table from [01_design.md §4.2](01_design.md) is retained and rendered below the OSS section — no Claude-design loss here.
 
@@ -338,14 +336,14 @@ The "Full Catalogue" `<details>` table from [01_design.md §4.2](01_design.md) i
 
 Vertical timeline driven by `D.experiences`:
 
-* `<h1>` reads "The career, as <span class="accent">uptime</span>." — playing on the `/runtime` route name.
-* Sub: `Seven roles. Four regulated industries. Measured outcomes per role — not just titles.`
-* Each `.tl-entry`: company headline, role + industry pill, period (mono right-aligned), 4-up `tl-metrics` grid (each metric shows value, label, dashed-bordered detail), two-column `tl-cols` for tech and leadership lists.
-* Per-entry node colour driven by `data-accent` (`brand | status | infra | human | impact | stack`) — controls the dot ring at `tl-entry::before`.
-* Vertical line: `linear-gradient(to bottom, var(--brand), var(--infra), var(--human))` at 0.5 opacity.
-* Reference: [app.js:391-424](design/suryaavala-com/project/app.js).
-* **Per-role metric count varies** (Montu carries 4, Linktree/Eliiza 2, Amber/ANZ/nib/HammondCare 1). The `tl-metrics` grid is `grid-template-columns: repeat(4, 1fr)` and gracefully fills 1–4 cells; ≤800px it collapses to 2 columns. No padding cells — empty space stays empty.
-* **Sub-line accuracy:** the page sub reads "Seven roles. Five regulated industries." — sourced from `aggregates.roleCount` and `aggregates.industryCount` (§6.y), **not** hard-coded. The unique industry set across `D.experiences` is `{Healthcare, Energy, Consumer Tech, Finance, Consulting} = 5`. The Claude prototype's hard-coded "Four regulated industries." string in [app.js:396](design/suryaavala-com/project/app.js) is a **prototype bug** and is corrected in this spec to match the build-time aggregate, mirroring the same fix applied to the "By the Numbers" Bento card in commit `9ab9d9e`.
+- `<h1>` reads "The career, as <span class="accent">uptime</span>." — playing on the `/runtime` route name.
+- Sub: `Seven roles. Four regulated industries. Measured outcomes per role — not just titles.`
+- Each `.tl-entry`: company headline, role + industry pill, period (mono right-aligned), 4-up `tl-metrics` grid (each metric shows value, label, dashed-bordered detail), two-column `tl-cols` for tech and leadership lists.
+- Per-entry node colour driven by `data-accent` (`brand | status | infra | human | impact | stack`) — controls the dot ring at `tl-entry::before`.
+- Vertical line: `linear-gradient(to bottom, var(--brand), var(--infra), var(--human))` at 0.5 opacity.
+- Reference: [app.js:391-424](design/suryaavala-com/project/app.js).
+- **Per-role metric count varies** (Montu carries 4, Linktree/Eliiza 2, Amber/ANZ/nib/HammondCare 1). The `tl-metrics` grid is `grid-template-columns: repeat(4, 1fr)` and gracefully fills 1–4 cells; ≤800px it collapses to 2 columns. No padding cells — empty space stays empty.
+- **Sub-line accuracy:** the page sub reads "Seven roles. Five regulated industries." — sourced from `aggregates.roleCount` and `aggregates.industryCount` (§6.y), **not** hard-coded. The unique industry set across `D.experiences` is `{Healthcare, Energy, Consumer Tech, Finance, Consulting} = 5`. The Claude prototype's hard-coded "Four regulated industries." string in [app.js:396](design/suryaavala-com/project/app.js) is a **prototype bug** and is corrected in this spec to match the build-time aggregate, mirroring the same fix applied to the "By the Numbers" Bento card in commit `9ab9d9e`.
 
 **GitHub Streak Widget:** Continues to live at the **footer** of `/runtime` per [01_design.md §4.3](01_design.md), with the same CSP allowlist for `streak-stats.demolab.com`.
 
@@ -353,19 +351,19 @@ Vertical timeline driven by `D.experiences`:
 
 Two-column desktop layout (`1.1fr 1fr`):
 
-* **Left:** 7 stack categories from `D.stackCategories`, each: square-bullet mono heading colour-keyed to category accent, then a wrap row of accent-tinted pills.
-* **Right (sticky `top: 80px`):** Radar chart inside `.radar-wrap`, with an evidence footnote in mono muted: *"Scores reflect production execution breadth across 10+ years — not academic certification."*
-* Reference: [app.js:426-489](design/suryaavala-com/project/app.js).
+- **Left:** 7 stack categories from `D.stackCategories`, each: square-bullet mono heading colour-keyed to category accent, then a wrap row of accent-tinted pills.
+- **Right (sticky `top: 80px`):** Radar chart inside `.radar-wrap`, with an evidence footnote in mono muted: _"Scores reflect production execution breadth across 10+ years — not academic certification."_
+- Reference: [app.js:426-489](design/suryaavala-com/project/app.js).
 
 Stack category list and competency scores are sourced from `D.stackCategories` and `D.competency` in `data.js` (see §6.x for the typed-data delta from v1).
 
 ### 4.5 Notes (`/notes`)
 
-* `<h1>`: "Long-form, <span class="accent">practitioner-anchored</span>."
-* `.note` rows in a vertical list: 3-col grid `120px 1fr auto` (date · body · `read →`).
-* Body: 18px sans heading, 14px sans description, meta row with mono brand-coloured `› {category}`, infra pills for tags, and `∫ KaTeX` mono yellow tag if `frontmatter.requiresMath`.
-* Hover lifts border to `var(--brand)` and translates `+2px X`.
-* Reference: [app.js:491-514](design/suryaavala-com/project/app.js).
+- `<h1>`: "Long-form, <span class="accent">practitioner-anchored</span>."
+- `.note` rows in a vertical list: 3-col grid `120px 1fr auto` (date · body · `read →`).
+- Body: 18px sans heading, 14px sans description, meta row with mono brand-coloured `› {category}`, infra pills for tags, and `∫ KaTeX` mono yellow tag if `frontmatter.requiresMath`.
+- Hover lifts border to `var(--brand)` and translates `+2px X`.
+- Reference: [app.js:491-514](design/suryaavala-com/project/app.js).
 
 MDX content pipeline (remark-math, rehype-katex, Shiki) inherited verbatim from [01_design.md §4.5](01_design.md).
 
@@ -386,17 +384,18 @@ The full five-channel matrix from [01_design.md §4.6](01_design.md) is preserve
 
 Triggered by **any** element with `data-open-contact` (in v2 that is the Bold-hero status board CTA, but additional triggers can be added without changing the modal). Closed by:
 
-* the `.cm-close` button,
-* clicking the `.cm-backdrop`,
-* pressing `Esc`,
-* navigating to a different route.
+- the `.cm-close` button,
+- clicking the `.cm-backdrop`,
+- pressing `Esc`,
+- navigating to a different route.
 
 Hotkeys when open: `G | L | E | W | C | S` open the corresponding channel in a new tab (or `window.location.href` for `mailto:`).
 
 Accessibility:
-* `role="dialog" aria-modal="true" aria-labelledby="contact-modal-title"`.
-* On open, `_cmLastFocus` saves `document.activeElement` and focus moves to the first row; on close, focus is restored.
-* `body.is-modal-open` locks scroll.
+
+- `role="dialog" aria-modal="true" aria-labelledby="contact-modal-title"`.
+- On open, `_cmLastFocus` saves `document.activeElement` and focus moves to the first row; on close, focus is restored.
+- `body.is-modal-open` locks scroll.
 
 Reference: [app.js:734-817](design/suryaavala-com/project/app.js), [home-bold.css:438-662](design/suryaavala-com/project/home-bold.css), [index.html:84-102](design/suryaavala-com/project/index.html).
 
@@ -408,9 +407,9 @@ Inherits §5 of [01_design.md](01_design.md) verbatim — accessibility, SEO, JS
 
 ### 5.1 Accessibility (additions)
 
-* **Reduced motion:** Required guards on the typing animation, count-up, status-board flippers, page-in transition, status beacon pulse, modal pop-in, sparkline reveal, and CTA pulse. The Claude bundle's `@media (prefers-reduced-motion: reduce)` block in [styles.css:118-124](design/suryaavala-com/project/styles.css) is the baseline; per-component overrides in [home-bold.css:151-155](design/suryaavala-com/project/home-bold.css) extend it.
-* **Focus-visible:** `outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px` on every focusable element. Already token-driven, but must survive any utility-class override.
-* **Modal trap:** The Contact Modal must trap focus within `.cm-panel` while open and restore on close. The Claude prototype implements focus restoration but **not** focus trap — this is a v2 must-fix in the Astro implementation.
+- **Reduced motion:** Required guards on the typing animation, count-up, status-board flippers, page-in transition, status beacon pulse, modal pop-in, sparkline reveal, and CTA pulse. The Claude bundle's `@media (prefers-reduced-motion: reduce)` block in [styles.css:118-124](design/suryaavala-com/project/styles.css) is the baseline; per-component overrides in [home-bold.css:151-155](design/suryaavala-com/project/home-bold.css) extend it.
+- **Focus-visible:** `outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px` on every focusable element. Already token-driven, but must survive any utility-class override.
+- **Modal trap:** The Contact Modal must trap focus within `.cm-panel` while open and restore on close. The Claude prototype implements focus restoration but **not** focus trap — this is a v2 must-fix in the Astro implementation.
 
 ### 5.2 CSP
 
@@ -420,8 +419,8 @@ CSP from [01_design.md §5.2](01_design.md) carries over. The `font-src` allowli
 
 `<title>` and `<meta description>` lifted from [index.html:6-7](design/suryaavala-com/project/index.html):
 
-* Title: `Surya Avala — Staff ML Engineer & Principal AI Systems Architect`
-* Description: `A decade of making ML systems survive production in healthcare and energy — where the plumbing matters more than the model.`
+- Title: `Surya Avala — Staff ML Engineer & Principal AI Systems Architect`
+- Description: `A decade of making ML systems survive production in healthcare and energy — where the plumbing matters more than the model.`
 
 JSON-LD Person schema unchanged from [01_design.md §5.2](01_design.md).
 
@@ -439,14 +438,14 @@ To support the new sparklines, Bold-variant KPI strip, status-board flipper, and
 // Metric — additive: unit + spark for inline sparkline rendering
 export interface Metric {
   value: string;
-  direction: '↑' | '↓' | '=' | '';   // '=' for "Prod"-style status metrics, '' for none
-  unit: string;                       // NEW — e.g. "%", "+", "x", ""
+  direction: '↑' | '↓' | '=' | ''; // '=' for "Prod"-style status metrics, '' for none
+  unit: string; // NEW — e.g. "%", "+", "x", ""
   label: string;
   context: string;
   methodology?: string;
   confidenceBound?: ConfidenceBound;
   accent: string;
-  spark?: number[];                   // NEW — 5–9 normalised values for sparkPath()
+  spark?: number[]; // NEW — 5–9 normalised values for sparkPath()
 }
 
 // Project — accent renamed to align with token names
@@ -454,37 +453,41 @@ export interface Project {
   slug: string;
   title: string;
   description: string;
-  domain: 'GenAI & Agentic Systems' | 'Systems & Infrastructure' | 'ML & Data Science'
-        | 'Data Engineering & Tooling' | 'Enterprise ML & Document Intelligence';
+  domain:
+    | 'GenAI & Agentic Systems'
+    | 'Systems & Infrastructure'
+    | 'ML & Data Science'
+    | 'Data Engineering & Tooling'
+    | 'Enterprise ML & Document Intelligence';
   repoUrl: string;
   tags: string[];
-  accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack';   // NEW — token key, not hex
+  accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack'; // NEW — token key, not hex
   featured: boolean;
-  badge?: 'Featured' | 'Latest';      // RENAMED from badgeLabel for parity with data.js
+  badge?: 'Featured' | 'Latest'; // RENAMED from badgeLabel for parity with data.js
 }
 
 // Contact — new module, mirrors D.contacts in the Claude bundle
 export interface Contact {
-  channel: string;                    // e.g. "GitHub"
-  handle: string;                     // e.g. "@suryaavala"
-  label: string;                      // mono CTA — e.g. "follow", "connect"
-  url: string;                        // https:// or mailto:
+  channel: string; // e.g. "GitHub"
+  handle: string; // e.g. "@suryaavala"
+  label: string; // mono CTA — e.g. "follow", "connect"
+  url: string; // https:// or mailto:
   accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack';
   logo: 'github' | 'linkedin' | 'gmail' | 'firefox' | 'coffee' | 'sponsor';
-  sla: string;                        // e.g. "replies < 24h"
+  sla: string; // e.g. "replies < 24h"
 }
 
 // HeroPhrases — new module, drives the typing island
 export interface HeroConfig {
   name: string;
-  prompt: string;                     // e.g. "~/whoami → surya"
-  headlineSafe: string;               // displayed in Safe variant
-  headlineBold: string;               // displayed in Bold variant
+  prompt: string; // e.g. "~/whoami → surya"
+  headlineSafe: string; // displayed in Safe variant
+  headlineBold: string; // displayed in Bold variant
   subhead: string;
   tagline: string;
-  phrases: string[];                  // typing cycle
+  phrases: string[]; // typing cycle
   industries: string[];
-  stack: { label: string; accent: 'brand'|'status'|'infra'|'impact'|'human'|'stack' }[];
+  stack: { label: string; accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack' }[];
 }
 
 // CompetencyAxis — unchanged from v1; methodology stays required (≥10 chars)
@@ -511,24 +514,28 @@ export const MetricSchema = z.object({
   methodology: z.string().min(10).optional(),
   confidenceBound: ConfidenceBoundSchema.optional(),
   accent: accentEnum,
-  spark: z.array(z.number()).min(5).max(9).optional(),
+  spark: z.array(z.number()).min(5).max(9).optional()
 });
 
 export const ContactSchema = z.object({
   channel: z.string().min(1),
   handle: z.string().min(1),
   label: z.string().min(1),
-  url: z.string().refine(s => s.startsWith('http') || s.startsWith('mailto:'),
-                         'url must be http(s) or mailto'),
+  url: z
+    .string()
+    .refine(
+      (s) => s.startsWith('http') || s.startsWith('mailto:'),
+      'url must be http(s) or mailto'
+    ),
   accent: accentEnum,
-  logo: z.enum(['github','linkedin','gmail','firefox','coffee','sponsor']),
-  sla: z.string().min(3),
+  logo: z.enum(['github', 'linkedin', 'gmail', 'firefox', 'coffee', 'sponsor']),
+  sla: z.string().min(3)
 });
 
 export const StackCategorySchema = z.object({
   name: z.string().min(1),
   accent: accentEnum,
-  items: z.array(z.string().min(1)).min(1),
+  items: z.array(z.string().min(1)).min(1)
 });
 
 // HeroConfigSchema, ProjectSchema, ExperienceSchema → trivial Zod equivalents
@@ -548,15 +555,15 @@ The "By the Numbers" Bento card (§4.1.A row 4) and the `/runtime` "Seven roles.
 ```typescript
 // /src/lib/aggregates.ts
 import { experiences } from '../data/experiences';
-import { metrics }     from '../data/metrics';
-import { upstream }    from '../data/upstream';
+import { metrics } from '../data/metrics';
+import { upstream } from '../data/upstream';
 
 export const aggregates = {
-  decadeYears:     10,                                                // hard-coded; review annually
-  industryCount:   new Set(experiences.map(e => e.industry)).size,
-  roleCount:       experiences.length,
-  metricCount:     metrics.length,
-  upstreamPRCount: upstream.length,
+  decadeYears: 10, // hard-coded; review annually
+  industryCount: new Set(experiences.map((e) => e.industry)).size,
+  roleCount: experiences.length,
+  metricCount: metrics.length,
+  upstreamPRCount: upstream.length
 } as const;
 ```
 
@@ -566,11 +573,10 @@ Each consumer (`homeSafe.astro` for the Bento card, `runtime.astro` for the sub-
 
 ## 7. Open Questions / Risks
 
-* **[RESOLVED]** Two homepage variants vs one: ship both, gate behind dev-only Tweaks panel. Production users land on `safe` by default; users who want the editorial pitch can be linked directly to `/?variant=bold` (a small URL-param hook reads the param once on first paint and writes it to localStorage). See §3.5.
-* **[RESOLVED]** Tailwind vs hand-authored CSS: layered approach — Tailwind for utilities, hand-authored CSS for tokens, animations, OKLAB blends, and component shells. See §2.1.
-* **[RESOLVED]** Mono font swap (Fira Code → JetBrains Mono): JetBrains Mono is the Claude bundle's choice. Adopt it; keep Fira Code as fallback for offline / fontless contexts.
-* **[RESOLVED]** Project `accent` schema (hex vs token key): token key. Keeps the brand-swap honest. See §6.x.
-* **[OPEN]** End-user accent picker: the Tweaks panel is dev-only. If we want users to pick a personal accent, it needs (a) a discoverable UI surface in the nav or footer, (b) a query-param fallback for direct linking, (c) an analytics decision on whether per-user accents should affect the OG image. Decision deferred to post-launch RFC.
-* **[OPEN]** Mobile Bold variant: the editorial typography (`clamp(48px, 8vw, 108px)`) is striking on desktop but reads heavy on phones. Tablet/mobile breakpoints in [home-bold.css](design/suryaavala-com/project/home-bold.css) handle layout collapse, but we should validate the "wow" reads on a phone before defaulting any cohort to Bold.
-* **[OPEN]** Contact modal vs inline `/ping`: with the modal, fewer users will navigate to `/ping`, which weakens the analytics signal for "who reached out". If we care about funnel attribution, add an event hook on each modal channel click before launch.
-
+- **[RESOLVED]** Two homepage variants vs one: ship both, gate behind dev-only Tweaks panel. Production users land on `safe` by default; users who want the editorial pitch can be linked directly to `/?variant=bold` (a small URL-param hook reads the param once on first paint and writes it to localStorage). See §3.5.
+- **[RESOLVED]** Tailwind vs hand-authored CSS: layered approach — Tailwind for utilities, hand-authored CSS for tokens, animations, OKLAB blends, and component shells. See §2.1.
+- **[RESOLVED]** Mono font swap (Fira Code → JetBrains Mono): JetBrains Mono is the Claude bundle's choice. Adopt it; keep Fira Code as fallback for offline / fontless contexts.
+- **[RESOLVED]** Project `accent` schema (hex vs token key): token key. Keeps the brand-swap honest. See §6.x.
+- **[OPEN]** End-user accent picker: the Tweaks panel is dev-only. If we want users to pick a personal accent, it needs (a) a discoverable UI surface in the nav or footer, (b) a query-param fallback for direct linking, (c) an analytics decision on whether per-user accents should affect the OG image. Decision deferred to post-launch RFC.
+- **[OPEN]** Mobile Bold variant: the editorial typography (`clamp(48px, 8vw, 108px)`) is striking on desktop but reads heavy on phones. Tablet/mobile breakpoints in [home-bold.css](design/suryaavala-com/project/home-bold.css) handle layout collapse, but we should validate the "wow" reads on a phone before defaulting any cohort to Bold.
+- **[OPEN]** Contact modal vs inline `/ping`: with the modal, fewer users will navigate to `/ping`, which weakens the analytics signal for "who reached out". If we care about funnel attribution, add an event hook on each modal channel click before launch.

--- a/specs/02_design.md
+++ b/specs/02_design.md
@@ -1,0 +1,576 @@
+
+# DESIGN_SPEC.md — v2 (Claude Design Variant)
+
+**Document Owner:** Staff Software Engineer / TPM
+
+**Project:** `suryaavala.com` v2.1 (Personal Architecture Platform — Editorial + Bento dual-variant)
+
+**Target Audience:** CTOs, Executive Recruiters, Peer Researchers, Staff Engineers
+
+**Status:** DRAFT — supersedes the visual / UX layers of [01_design.md](01_design.md)
+
+**Source:** Claude Design handoff bundle at [specs/design/suryaavala-com/](design/suryaavala-com/) — `index.html`, `styles.css`, `home-safe.css`, `home-bold.css`, `pages.css`, `app.js`, `data.js`, `Design System.html`. Pixel-perfect parity with the bundle's HTML/CSS prototypes is the acceptance criterion for §3 and §4.
+
+**Relationship to v1:** This document **inherits unchanged** the system architecture (§2), accessibility / SEO / CSP cross-cutting concerns (§5), and data integrity / Zod schema (§6) from [01_design.md](01_design.md), with the small typed-data deltas explicitly called out in §6.x. It **replaces** the visual language (§3.1), component library (§3.2), homepage Bento logic (§4.1), and per-page chrome of v1 with the Claude Design vocabulary.
+
+---
+
+## 1. Context & Scope
+
+### 1.1 Background
+
+Identical positioning to [01_design.md §1.1](01_design.md): Surya Avala — Principal AI Systems Architect, Staff ML Engineer, Engineering Leader. The "Full-Stack Regulated Convergence (Math + Agents + Scale + Security)" thesis is unchanged.
+
+What changes here is **how** that thesis is expressed in the browser. Two parallel hero modes are now in scope:
+
+* **Safe · Bento** — the v1-faithful 4×N grid, expanded to 9 semantic nodes with sparklines and a build-computed "By the Numbers" card.
+* **Bold · Editorial** — an editorial typographic hero (clamp 48–108px italic gradient title), a flipping status board, a terminal-styled sidebar, a borderless 4-up KPI strip, and three section blocks below the fold.
+
+Both variants serve the same data, the same audiences, and the same eight-second scanning promise. The variant switch lives in a developer-facing **Tweaks panel** (§3.5) and is persisted to `localStorage`. Default is `safe` for first-time visitors.
+
+### 1.2 Goals
+
+* **Visual parity with the handoff bundle.** The Astro implementation must match [specs/design/suryaavala-com/project/index.html](design/suryaavala-com/project/index.html) and its imports at the level of layout grids, token values, easing curves, hover transitions, and animation cadence. Recreate; do not reinterpret.
+* **Maximum performance** (Lighthouse 100/100, all four pillars), inherited from v1.
+* **Frictionless authoring** (Local MDX), inherited from v1.
+* **Identity-preserving theming** — six brand-accent swatches and a light/dark theme toggle. Both must persist across navigations and survive a hard reload.
+
+### 1.3 Non-Goals
+
+Inherits all non-goals from [01_design.md §1.3](01_design.md). Additionally:
+
+* **NO design-system CSS framework lock-in.** The Claude design is hand-authored CSS with custom properties, `color-mix(in oklab, …)`, and OKLAB blends. Tailwind is retained for utility classes (§2.1), but the canonical visual contract is the token set in §3.1 — consumed via Tailwind's `theme.extend` and via per-component `<style>` blocks. Do not rewrite the Claude CSS into utility-only Tailwind; that loses the OKLAB blends and the named-pseudo cascades the bundle relies on.
+* **NO third hero variant.** Two variants only. If a third is requested, it gets its own RFC.
+
+---
+
+## 2. System Architecture
+
+### 2.1 Tech Stack
+
+Identical to [01_design.md §2.1](01_design.md), with one styling-engine clarification:
+
+* **Core Framework (Routing & SSG):** `Astro` (v4+).
+* **Interactive Components (Islands):** `Svelte`.
+* **Styling Engine:** `Tailwind CSS` for utility classes, **layered over** a hand-authored token sheet (`/src/styles/tokens.css`) and per-component `<style>` blocks. Tokens from §3.1 are exposed both as CSS custom properties (for `color-mix`, OKLAB blends, gradient stops) and as Tailwind theme extensions (for `bg-brand`, `text-impact`, etc.). Per-component CSS — hero card, status board, KPI strip, terminal sidebar, contact modal, radar — is lifted verbatim from the handoff bundle and re-scoped to Astro components.
+* **Content Pipeline:** Local `MDX` (Markdown + embedded Svelte components).
+* **Package Manager:** `npm` with strict lockfile enforcement (`npm ci` in CI).
+
+### 2.2 Data Flow & Infrastructure
+
+Unchanged from [01_design.md §2.2](01_design.md). Source of truth in `/src/content/notes/` and `/src/data/`; GitHub Actions → `gh-pages` → GitHub Pages → Cloudflare proxy with Full/Strict TLS, edge cache, and DDoS protection. `CNAME` file in `public/`.
+
+The Claude bundle's `data.js` is a **client-side mirror** of the typed-data modules; in production these are the same TypeScript modules in `/src/data/` (§6.2), imported at build-time and rendered into static HTML — no runtime fetch.
+
+---
+
+## 3. UX/UI Specification
+
+### 3.1 Visual Language (Design Tokens)
+
+Authoritative token sheet — copy verbatim into `/src/styles/tokens.css`. These values are lifted from [styles.css](design/suryaavala-com/project/styles.css) and confirmed against [Design System.html](design/suryaavala-com/project/Design%20System.html).
+
+```css
+:root {
+  /* Type */
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Dark — primary theme */
+  --bg:        #0d1117;   /* GitHub Dark base */
+  --bg-2:      #11161d;
+  --surface:   #161b22;
+  --surface-2: #1b2129;
+  --surface-3: #21262d;
+  --border:    #30363d;
+  --border-soft: #222830;
+  --text:      #f8f8f2;   /* Dracula foreground */
+  --text-2:    #c9d1d9;
+  --text-muted: #7a8bc0;
+  --text-faint: #4e5872;
+
+  /* Dracula accents */
+  --brand:      #bd93f9;  /* purple */
+  --brand-body: #c4a0ff;  /* AA on dark for body-size purple */
+  --status:     #50fa7b;  /* green */
+  --infra:      #8be9fd;  /* cyan */
+  --impact:     #ffb86c;  /* orange */
+  --human:      #ff79c6;  /* pink */
+  --stack:      #f1fa8c;  /* yellow */
+  --danger:     #ff5555;  /* red */
+
+  /* Radii */
+  --radius-sm: 6px;
+  --radius:    10px;
+  --radius-lg: 14px;
+
+  /* Motion */
+  --easing: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --shadow-glow: 0 0 0 1px rgba(189, 147, 249, 0.12),
+                 0 24px 60px -30px rgba(189, 147, 249, 0.35);
+}
+
+:root.light {
+  /* WCAG AA-tuned light palette — DEEPER accents than v1's brightened variants */
+  --bg:        #f6f7f9;
+  --bg-2:      #eceff4;
+  --surface:   #ffffff;
+  --surface-2: #f1f3f7;
+  --surface-3: #e6eaf0;
+  --border:      #c8d0db;   /* stronger separation against #fff surfaces */
+  --border-soft: #dde2ea;
+  --text:        #0b1220;
+  --text-2:      #1f2937;
+  --text-muted:  #3b475a;   /* AA ≥7:1 on bg/surface */
+  --text-faint:  #6b7280;   /* AA ≥4.5:1 on surface */
+
+  --brand:      #5b21b6;    /* deeper purple — AA on white */
+  --brand-body: #5b21b6;
+  --status:     #0f6b34;
+  --infra:      #075e7a;
+  --impact:     #9a3412;
+  --human:      #9d174d;
+  --stack:      #854d0e;
+  --danger:     #9b1c1c;
+
+  --shadow-glow: 0 0 0 1px rgba(91, 33, 182, 0.14),
+                 0 20px 40px -20px rgba(91, 33, 182, 0.28);
+}
+```
+
+**Typography deltas vs v1:**
+* Mono family is **`JetBrains Mono`** (not Fira Code). Fira Code remains as a fallback only.
+* Inter is loaded with weights `400;500;600;700` and the OpenType features `cv02 cv03 cv04 cv11 ss01` enabled at the `<html>` level (matching the Claude bundle's `font-feature-settings`).
+
+**Background ambient layer:** A fixed full-viewport CSS grid pattern (`64px × 64px` lines at `color-mix(in oklab, var(--border) 50%, transparent)`) masked with a top-anchored radial fade. Opacity `0.35` in dark mode, `0.55` in light mode. Painted via `body::before`. Pure CSS, zero JS, zero asset weight.
+
+**WCAG note:** Light-mode accents above are intentionally darker than v1's brightened token set — these are tuned to pass AA against the `#ffffff` surface used for cards, not just the `#f6f7f9` page background. Dark-mode contrast claims from [01_design.md §3.1](01_design.md) carry over unchanged.
+
+### 3.2 Component Library
+
+Components below are the Claude vocabulary. Each is implemented as either a server-rendered Astro component (no JS) or a Svelte Island (interactive). Pixel parity targets the noted source files in [specs/design/suryaavala-com/project/](design/suryaavala-com/project/).
+
+| Component | Astro / Svelte | Source CSS | Notes |
+|---|---|---|---|
+| **Glass Nav** (sticky, `backdrop-filter: blur(16px) saturate(160%)`) | Astro | `styles.css` `.nav` | Mono `~/suryaavala.com` brand, slash-prefixed mono links (`/architecture`, `/runtime`, …), gradient underline `linear-gradient(90deg, var(--brand), var(--infra))` on `.active`. Hides `.cta-btn` below 1024px (status board carries it on mobile). |
+| **Brand Mark Logo** | Astro | `.brand-mark .logo` | 28×28 rounded square, `linear-gradient(135deg, var(--brand), var(--human))`, bg-coloured "SA" glyph. |
+| **Theme Toggle** | Svelte | `styles.css` `.icon-btn` | Sun/moon SVG swap. Persists to `localStorage["sa-theme"]`. Inline pre-FOUC script applies the saved class on `<html>` before paint (lift verbatim from [index.html:15-21](design/suryaavala-com/project/index.html)). |
+| **CTA Pill** ("Open to Work") | Astro | `.cta-btn` | Border + bg `var(--surface)`, 8px pulsing dot in `var(--status)` with 2s `ease-in-out` ring animation. |
+| **Bento Grid (Safe variant)** | Astro | `home-safe.css` `.bento` | `grid-template-columns: repeat(4, minmax(0,1fr))`, `grid-auto-rows: minmax(200px, auto)`, `gap: 16px`. Per-card spans listed in §4.1.A. |
+| **Hero Card (Safe)** | Astro + Svelte typing island | `.hero-card`, `.hero-name`, `.hero-type`, `.hero-tagline` | Two radial gradients overlay `var(--surface)`. Name with gradient-clipped first word (`background-clip: text`, `linear-gradient(90deg, var(--brand), var(--human))`). Italic mono tagline left-bordered with `2px solid var(--brand)`. |
+| **Typing Hero** | Svelte Island | `.hero-type .cursor` | Cycles `D.hero.phrases`. `Fira Code → JetBrains Mono`, color `var(--brand-body)`. Char-add cadence ~55ms, char-delete ~30ms, end-of-word pause 1400ms. Cursor: 2px-wide block with `blink 1s steps(2)`. |
+| **Metric (Bento Impact card)** | Astro + Svelte count-up island | `.metric`, `.metric-value`, `.spark` | 32px mono value in `var(--impact)` with mini-arrow `direction`, descriptive `label`, cyan `metric-ctx` (sourced from `metric.context`), faint `metric-method` (sourced from `metric.method`), 22px-tall inline SVG sparkline (`stroke: var(--impact)`, `opacity: 0.55`). Sparkline path computed from `metric.spark: number[]` via §3.6 helper. Count-up triggered by `IntersectionObserver` on first scroll-into-view; `aria-live="polite"` for SR. |
+| **Status Beacon** | Astro | `.status-beacon` | 10px green dot, 3px ring, 2s `pulse` keyframe. |
+| **Status Board (Bold variant)** | Svelte Island | `home-bold.css` `.status-board` | Horizontal bar: pulsing LED · `Open to Work` · location flipper · separator · role flipper · primary CTA. Two flippers run independently — location (4.2s interval, 1.8s delay), role (3.2s interval, 1.2s delay). Items rotate via `transform: translateY(60%) rotateX(-70deg) → translateY(0) rotateX(0)` with 0.42s `cubic-bezier(0.5, 0, 0.2, 1)`. The CTA opens the Contact Modal (§3.2 row below). All animations gated by `prefers-reduced-motion`. |
+| **Editorial Title (Bold)** | Astro | `.bold-title` | `font-family: var(--font-sans)`, `font-size: clamp(48px, 8vw, 108px)`, weight 500, `letter-spacing: -0.04em`, `line-height: 0.92`. Italicised `<em>` segment uses gradient-clipped text `linear-gradient(90deg, var(--brand) 0%, var(--human) 55%, var(--impact) 100%)`. Mono sub-headline at `0.35em`. |
+| **Terminal Sidebar (Bold hero)** | Astro | `.terminal`, `.term-bar`, `.term-body` | Card with macOS traffic-light dots, mono prompt lines, JSON-syntax-coloured output (`.k` cyan / `.s` yellow / `.v` orange). Static — no JS. |
+| **KPI Strip (Bold)** | Astro + count-up | `.kpi-strip`, `.kpi` | Borderless 4-up `display: grid` with internal soft borders. Big mono number with directional arrow + unit, label, ctx. Per-cell accent class `k-impact`/`k-status`/`k-infra`/`k-human` colours the number. |
+| **Featured / Latest Badge** | Astro | `.card-badge.featured`, `.card-badge.latest` | Absolute-positioned mono chip top-right; orange for Featured, cyan for Latest. |
+| **Card with Accent Hover** | Astro | `.card`, `.card--brand`, `.card--status`, … | Each card variant lifts a colour-mix shadow + border on hover: `box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 30%, transparent), 0 20px 40px -20px color-mix(in oklab, var(--accent) 45%, transparent)`. |
+| **Pill** (`.pill` + `.pill-{accent}`) | Astro | `styles.css` `.pill` | `font-family: var(--font-mono)`, 11.5px, color-mix accent border. Used everywhere tags appear. |
+| **Rainbow HR** | Astro | `.rainbow-hr` | 2px-tall `<hr>` with full Dracula gradient `linear-gradient(90deg, var(--danger), var(--impact), var(--stack), var(--status), var(--infra), var(--brand), var(--human))`, opacity 0.7. Used inside the Safe hero card. |
+| **Mission Slab (Bold §3)** | Astro | `home-bold.css` `.mission-slab` | Pink-tinted gradient surface, two-column layout: oversized mono glyph quote on the left, italic blockquote + mono `<cite>` on the right. Collapses to one column ≤ 700px. |
+| **Section Header** (`.sec-head`) | Astro | `home-bold.css` `.sec-head` | Numbered eyebrow (`01 /`, `02 /`, `03 /`) in mono muted colour, 22–30px clamp section title, dashed soft underline. Used between Bold-variant sections. |
+| **Timeline Entry** (`/runtime`) | Astro | `pages.css` `.timeline`, `.tl-entry` | Vertical gradient line `linear-gradient(to bottom, var(--brand), var(--infra), var(--human))` at 0.5 opacity. Per-entry node colour driven by `data-accent`. 4-up metric grid per role with dashed-bordered detail row. Two-column tech / leadership lists. |
+| **Project Card** (`/architecture`) | Astro | `.proj` | Mono title, hover lifts 2px and switches border to `var(--brand)`, accent-coloured pill row. |
+| **Stack Category** + **Radar Chart** (`/stack`) | Astro + Svelte radar island | `pages.css` `.stack-page`, `.radar-wrap` | Two-column desktop layout `1.1fr 1fr`. Categories left, sticky radar right. Radar = inline SVG (§3.4) with hover tooltips bound to dot circles. |
+| **Note Row** (`/notes`) | Astro | `.note` | 3-column grid (date · body · `read →`). Hover lifts border to `var(--brand)`, translates `+2px` on X. Mono `∫ KaTeX` tag if `frontmatter.requiresMath`. |
+| **Shield Row + Contact Card** (`/ping`) | Astro | `pages.css` `.shield`, `.contact` | README-style shields in a wrap row at hero foot; below, a 3-up grid of cards with channel-specific `c-{accent}` modifier — left 3px accent ribbon, accent-tinted handle, channel-coloured hover glow. SVG glyphs (GitHub, LinkedIn, Gmail, Firefox, Coffee, Sponsor) lifted from [app.js:516-528](design/suryaavala-com/project/app.js). |
+| **Traceroute Block** (`/ping` foot) | Astro | `.ping-fun` | Dashed-border block with diagonal `repeating-linear-gradient` brand-tinted background. Three mono rows: `1 github.com … 1.2ms`, `2 linkedin.com … 2.4ms`, `3 inbox … ~24h`. Editorial easter egg, zero JS. |
+| **Contact Modal** | Svelte Island | `home-bold.css` `.contact-modal`, `.cm-*` | Centred 580px panel with backdrop blur + brand-tinted radial wash. Pop-in `cm-pop-in 0.28s` keyframe. Six rows, each: hotkey chip (G/L/E/W/C/S) · channel name + handle · SLA + action arrow. Esc closes. Hotkeys jump to channel. Focus is moved to first row on open and restored on close. `body.is-modal-open` locks scroll. |
+| **Tweaks Panel** | Svelte Island | `styles.css` `.tweaks` | Fixed bottom-right, 260px wide. Two controls: **Homepage variant** segmented toggle (Safe · Bold), **Brand accent** swatch row (Purple / Cyan / Green / Orange / Pink). Persists to `localStorage["sa-home-variant"]` and `localStorage["sa-accent"]`. Visible only when `parent.postMessage({type: "__activate_edit_mode"})` is received from the dev harness — production users see no tweaks panel. (See §3.5.) |
+| **Page Transition** | CSS | `styles.css` `.page` | `page-in 0.45s var(--easing) both`: from `opacity:0; translateY(8px); filter: blur(4px)` → `opacity:1; translateY(0); filter: blur(0)`. Re-triggered after each route change by removing/re-adding the class and forcing a reflow (`void container.offsetWidth`). |
+
+### 3.3 Site Map (Multi-Page Routing)
+
+Six routes — same as v1.
+
+1. **`/` (Home)** — Two variants (Safe Bento, Bold Editorial) selected by the Tweaks panel; default Safe.
+2. **`/architecture`** — Domain-grouped projects; OSS upstream block at anchor `#oss`.
+3. **`/runtime`** — Vertical timeline, 7 roles, accent-coloured nodes.
+4. **`/stack`** — Two-column layout: 7 stack categories + sticky radar chart.
+5. **`/notes`** — MDX list with category and KaTeX/Shiki support.
+6. **`/ping`** — Shields row + 6 contact cards + traceroute block.
+
+> **Audience routing intent (analytics-only, no personalisation):** unchanged from [01_design.md §3.3](01_design.md).
+
+The Claude bundle uses an SPA hash router for prototyping (`location.hash`, `render()` rebuilds `#page`); the Astro implementation **must** ship one HTML file per route — no client-side router. Keep the same URL shapes but drop the leading `#`. The Tweaks panel and Contact Modal continue to mount globally on every page.
+
+### 3.4 Radar Chart (Inline SVG, Svelte Island)
+
+Located on `/stack`, sticky in the right column at desktop ≥1000px. Identical mathematical shape to [01_design.md §4.4](01_design.md), but with the Claude colour treatment:
+
+* `viewBox="0 0 340 340"`, radius `120`, centred at `(170, 170)`.
+* Five concentric rings at `pct ∈ {20, 40, 60, 80, 100}`, stroked `var(--border-soft)` with `opacity: 0.6 - i*0.08`.
+* Axis lines stroked `var(--border)`.
+* Filled data polygon: `fill="var(--brand)"` at `fill-opacity="0.28"`, `stroke="var(--brand)"` `stroke-width="1.8"`, `stroke-linejoin="round"`.
+* Per-axis dot: `circle r="4.5"` filled `var(--stack)` (yellow), stroked `var(--bg)` 2px to punch out from the polygon.
+* Axis labels: `<text fill="var(--infra)" font-family="var(--font-mono)" font-size="10">`, anchored `start | end | middle` based on `Math.cos(a)` quadrant.
+* Hover tooltip: floats inside `#radar-container`, mono 11.5px, brand-bordered, displays `<b>{label}</b> <span class="score">{score}/100</span> <br>{method}` (the `method` field — see §6.x note on the v1→v2 field rename). Position tracked via `mouseenter` + `mousemove` listeners on each dot.
+
+Reference implementation in [app.js:453-489](design/suryaavala-com/project/app.js) (`radarSVG(axes)` and `initRadar()`). Self-assessment methodology footnote (§4.4) carries over unchanged.
+
+### 3.5 Tweaks Panel — variant + accent swap
+
+The Tweaks panel is **a developer affordance**, not a user-facing feature. It must be:
+
+1. **Hidden by default** in production. The panel only opens on receipt of a `parent.postMessage({type: "__activate_edit_mode"})` event — used by Claude Design's hosted preview iframe. In production hosting (`suryaavala.com` on GH Pages via Cloudflare), this message never arrives, so the panel never appears.
+2. **State-only persistence.** Selecting `Bold` variant writes `localStorage["sa-home-variant"] = "bold"`; on next page render, the home route reads this and renders the Bold template instead of Safe. Selecting an accent swatch writes `localStorage["sa-accent"]` and immediately mutates `--brand` and `--brand-body` on `:root.style`.
+3. **Five accent presets** with the following `(brand, brand-body)` pairs (lifted from [app.js:34-40](design/suryaavala-com/project/app.js)):
+
+   | Key      | `--brand`  | `--brand-body` |
+   |----------|------------|----------------|
+   | `purple` | `#bd93f9`  | `#c4a0ff`      |
+   | `cyan`   | `#8be9fd`  | `#b4f0ff`      |
+   | `green`  | `#50fa7b`  | `#7effa0`      |
+   | `orange` | `#ffb86c`  | `#ffce99`      |
+   | `pink`   | `#ff79c6`  | `#ffa2d6`      |
+
+4. **Defaults** stored under `EDITMODE-BEGIN ... EDITMODE-END` markers in source (so the Claude editor can rewrite them): `{"variant": "safe", "accent": "purple"}`.
+
+If the user wants an end-user-facing accent picker post-launch, it gets a separate RFC and a UI surface that is not the dev tweaks panel.
+
+### 3.6 Helpers & Animation Primitives
+
+Centralise in `/src/lib/`:
+
+* **`sparkPath(values, w=120, h=22)`** — returns an SVG `path d` string for a min-max-normalised polyline. Reference: [app.js:103-112](design/suryaavala-com/project/app.js).
+* **`animateCountUp(el, target, duration=1400)`** — `IntersectionObserver`-driven cubic ease-out, formatted decimals based on magnitude. Reference: [app.js:77-100](design/suryaavala-com/project/app.js).
+* **`startTyping(el, phrases)`** — typewriter effect with 55/30 ms cadence and 1400 ms pause. Reference: [app.js:56-74](design/suryaavala-com/project/app.js).
+* **`initRoleFlip()`** — manages flipboard rotation for the bold-hero status board. Reference: [app.js:633-665](design/suryaavala-com/project/app.js).
+* **`pingLogo(name)`** — returns one of the six channel SVG glyphs. Reference: [app.js:516-528](design/suryaavala-com/project/app.js).
+
+Every animation listed above must be wrapped in a `@media (prefers-reduced-motion: reduce)` guard that disables transform/opacity transitions while still flipping state — never hide content from users with motion sensitivity.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Homepage Logic — TWO variants
+
+The homepage is rendered by `pageHome()` which dispatches to `homeSafe()` or `homeBold()` based on `localStorage["sa-home-variant"]` (default `safe`). The header shell, footer, nav, and Contact Modal mount around either variant identically.
+
+#### 4.1.A — Safe Bento (default)
+
+The Bento grid is **9 semantic nodes** (one more than v1), arranged in a 4-column desktop grid that reflects signal hierarchy: enterprise platform work and quantified metrics get the largest spans. The new node — "By the Numbers" — surfaces *build-time computed* totals (number of distinct industries, number of roles, number of measured metrics, number of upstream PRs), giving the grid completeness without inventing claims.
+
+```
+┌─────────────────────────────────────────────────┐
+│                  hero (span 4)                  │
+├─────────────┬─────────────┬─────────┬───────────┤
+│             │             │ status  │  numbers  │
+│   impact    │   impact    ├─────────┴───────────┤
+│  (2x2 grid  │  cont.)     │      agentic        │
+│             │             │      (span 2)       │
+├─────────────┴─────────────┼─────────┬───────────┤
+│         lead              │ infra-hl│    oss    │
+│        (span 2)           │         │           │
+├───────────────────────────┴─────────┴───────────┤
+│                 beyond (span 2)                 │
+└─────────────────────────────────────────────────┘
+```
+
+| # | Card | Source | Span | Accent | Notes |
+|---|---|---|---|---|---|
+| 1 | **Hero** | `hero-card .hero` | `span 4` | brand | Mono `~/whoami → surya` prompt eyebrow, `<h1>` with gradient-clipped first word, typing line, italic mono tagline, hero-sub, industries row, stack-pill row, rainbow `<hr>` foot. |
+| 2 | **Impact Cluster** | `impact-card .impact` | `span 2 × span 2` | impact | 6 metrics in a 2-column inner grid. Each metric: count-up value + dir + unit, label, mono cyan `metric-ctx`, faint `metric-method`, 22px sparkline. |
+| 3 | **Status** | `status-card .status` | `span 1` | status | Beacon, primary copy, mono "last verified" footer, link to `/ping`. |
+| 4 | **By the Numbers** | `nums .numbers` | `span 1` | human | `<dl>` with `decade`, `industries shipped` (`new Set(D.experiences.map(e => e.industry)).size`), `shipped roles` (`D.experiences.length`), `measured outcomes` (`D.metrics.length`), `upstream PRs` (`D.upstream.length`). Foot: `computed at build · not a marketing claim`. |
+| 5 | **Agentic Highlight** | `agentic .feature-card` | `span 2` | infra | `Featured` badge. The featured project (`projects.find(p => p.badge === "Featured")` → `scaling-succotash`). Cyan eyebrow `⬢ Agentic · Prod`, mono mark `›`, infra pill row. |
+| 6 | **Infra Highlight** | `infra-hl .feature-card` | `span 1` | infra | `Latest` badge. The latest project (`projects.find(p => p.badge === "Latest")` → `traffic_counter`). |
+| 7 | **OSS Upstream** | `oss-card .oss` | `span 1` | status | Top-5 PRs from `D.upstream`, mono list, status-coloured arrows. Foot count: `5 merged PRs across MLOps + data infra`. |
+| 8 | **Leadership** | `lead` | `span 2` | impact | `⌘ Technical Leadership` eyebrow, `Staff+ signal` heading, RFC + ML Guild + Build vs Buy copy, hire/mentor quote. |
+| 9 | **Beyond Code** | `beyond` | `span 2` | human | `♁ Beyond Code` eyebrow, `Equitable outcomes` heading, mission line including `🥐 Pastry Enthusiast`. |
+
+Reference: [app.js:119-215](design/suryaavala-com/project/app.js) (`homeSafe()`).
+
+**Mobile collapse:** Below 1000px, `bento` becomes 2 columns (`hero/impact/agentic/lead/beyond` each `span 2`). Below 680px, a single column (`> *` becomes `span 1`). The `<details>` "Show more" toggle from v1 is **dropped** in this variant — the editorial weight is carried by the Bold variant for users who want a longer-form story.
+
+#### 4.1.B — Bold Editorial
+
+```
+┌─────────────────────────────┬───────────────┐
+│   ┌──────────────────────┐  │               │
+│   │   status-board       │  │   terminal    │
+│   ├──────────────────────┤  │   (whoami     │
+│   │  bold-title          │  │    --verbose) │
+│   │  (clamp 48-108px)    │  │               │
+│   ├──────────────────────┤  │               │
+│   │  bold-lede           │  │               │
+│   ├──────────────────────┤  │               │
+│   │  CTA primary + ghost │  │               │
+│   └──────────────────────┘  │               │
+└─────────────────────────────┴───────────────┘
+┌──────┬──────┬──────┬──────────────────────────┐
+│ KPI  │ KPI  │ KPI  │     KPI                  │
+└──────┴──────┴──────┴──────────────────────────┘
+
+§01 Featured work    [feat-row: featured | latest]
+§02 Upstream signal  [oss-list: 5 rows]
+§03 Beyond code      [mission-slab]
+```
+
+* **Hero grid:** `1.6fr 1fr` two-column, 48px gap, 48px top / 64px bottom padding. Collapses to single column ≤1000px.
+* **Status Board** (top-left of left column): described in §3.2; takes `bold-meta` slot.
+* **Bold Title:** `clamp(48px, 8vw, 108px)`, weight 500, italic gradient `<em>`, mono `<span class="sub">` sub-line at `0.35em`.
+* **Bold Lede:** 19px, max-width 620px, `text-wrap: pretty`. Bold inline strongs land in `var(--text)`.
+* **CTAs:** `.btn-primary` (filled brand bg, bg-coloured text) → `/architecture`; `.btn-ghost` → `/ping`.
+* **Terminal Sidebar:** macOS chrome (red/yellow/green dots), mono content, three command blocks with JSON-coloured output (`whoami --verbose`, `cat impact.json | jq .top`, blinking prompt).
+* **KPI Strip:** Borderless 4-up `grid-template-columns: repeat(4, 1fr)` inside a single bordered card. Internal soft borders `border-right: 1px solid var(--border-soft)`. Picks `D.metrics[0..3]` and assigns accents `[impact, status, infra, human]` in order. Below 900px: 2 columns. Below 540px: 1 column.
+* **Sections (`§01–§03`):** numbered `sec-head` titles, dashed soft underline, content row beneath:
+  * **§01 Featured work** — 2:1 grid (featured | latest), reusing `.feature-card`.
+  * **§02 Upstream signal** — vertical list of 5 `.oss-row` rows, mono, status-coloured PR numbers.
+  * **§03 Beyond code** — `.mission-slab`: pink-tinted gradient card with oversized mono glyph quote on the left, italic blockquote + uppercase mono `<cite>` on the right.
+
+Reference: [app.js:217-351](design/suryaavala-com/project/app.js) (`homeBold()`).
+
+### 4.2 Architecture (`/architecture`)
+
+* `page-head` with mono `/architecture` eyebrow, `<h1>` with brand-coloured `<span class="accent">` for "architectural domain".
+* Projects grouped by `Project.domain`, rendered as `.proj` cards in a 3-column grid (2 col ≤1000px, 1 col ≤680px).
+* OSS section pinned at `#oss` anchor with status-coloured heading and 5 `.oss-row` entries linking to GitHub PRs in new tabs.
+* Domain order (deterministic): `GenAI & Agentic Systems → Systems & Infrastructure → ML & Data Science → Data Engineering & Tooling → Enterprise ML & Document Intelligence`.
+* Reference: [app.js:353-389](design/suryaavala-com/project/app.js).
+
+The "Full Catalogue" `<details>` table from [01_design.md §4.2](01_design.md) is retained and rendered below the OSS section — no Claude-design loss here.
+
+### 4.3 Runtime (`/runtime`)
+
+Vertical timeline driven by `D.experiences`:
+
+* `<h1>` reads "The career, as <span class="accent">uptime</span>." — playing on the `/runtime` route name.
+* Sub: `Seven roles. Four regulated industries. Measured outcomes per role — not just titles.`
+* Each `.tl-entry`: company headline, role + industry pill, period (mono right-aligned), 4-up `tl-metrics` grid (each metric shows value, label, dashed-bordered detail), two-column `tl-cols` for tech and leadership lists.
+* Per-entry node colour driven by `data-accent` (`brand | status | infra | human | impact | stack`) — controls the dot ring at `tl-entry::before`.
+* Vertical line: `linear-gradient(to bottom, var(--brand), var(--infra), var(--human))` at 0.5 opacity.
+* Reference: [app.js:391-424](design/suryaavala-com/project/app.js).
+* **Per-role metric count varies** (Montu carries 4, Linktree/Eliiza 2, Amber/ANZ/nib/HammondCare 1). The `tl-metrics` grid is `grid-template-columns: repeat(4, 1fr)` and gracefully fills 1–4 cells; ≤800px it collapses to 2 columns. No padding cells — empty space stays empty.
+* **Sub-line accuracy:** the page sub reads "Seven roles. Five regulated industries." — sourced from `aggregates.roleCount` and `aggregates.industryCount` (§6.y), **not** hard-coded. The unique industry set across `D.experiences` is `{Healthcare, Energy, Consumer Tech, Finance, Consulting} = 5`. The Claude prototype's hard-coded "Four regulated industries." string in [app.js:396](design/suryaavala-com/project/app.js) is a **prototype bug** and is corrected in this spec to match the build-time aggregate, mirroring the same fix applied to the "By the Numbers" Bento card in commit `9ab9d9e`.
+
+**GitHub Streak Widget:** Continues to live at the **footer** of `/runtime` per [01_design.md §4.3](01_design.md), with the same CSP allowlist for `streak-stats.demolab.com`.
+
+### 4.4 Stack (`/stack`)
+
+Two-column desktop layout (`1.1fr 1fr`):
+
+* **Left:** 7 stack categories from `D.stackCategories`, each: square-bullet mono heading colour-keyed to category accent, then a wrap row of accent-tinted pills.
+* **Right (sticky `top: 80px`):** Radar chart inside `.radar-wrap`, with an evidence footnote in mono muted: *"Scores reflect production execution breadth across 10+ years — not academic certification."*
+* Reference: [app.js:426-489](design/suryaavala-com/project/app.js).
+
+Stack category list and competency scores are sourced from `D.stackCategories` and `D.competency` in `data.js` (see §6.x for the typed-data delta from v1).
+
+### 4.5 Notes (`/notes`)
+
+* `<h1>`: "Long-form, <span class="accent">practitioner-anchored</span>."
+* `.note` rows in a vertical list: 3-col grid `120px 1fr auto` (date · body · `read →`).
+* Body: 18px sans heading, 14px sans description, meta row with mono brand-coloured `› {category}`, infra pills for tags, and `∫ KaTeX` mono yellow tag if `frontmatter.requiresMath`.
+* Hover lifts border to `var(--brand)` and translates `+2px X`.
+* Reference: [app.js:491-514](design/suryaavala-com/project/app.js).
+
+MDX content pipeline (remark-math, rehype-katex, Shiki) inherited verbatim from [01_design.md §4.5](01_design.md).
+
+### 4.6 Ping (`/ping`)
+
+Three vertical sections:
+
+1. **Hero + Shields row** — `page-head` followed by `ping-shields`: 6 inline `<a class="shield shield-{accent}">` chips, each with an inline SVG channel logo and a mono uppercase label (`follow`, `connect`, `get in touch`, `read`, `caffeinate`, `sponsor`).
+2. **Contact Grid** — section eyebrow `$ cat channels.md // 6 endpoints · 1 human`, then a 3-up grid (2-up ≤900px, 1-up ≤600px) of `.contact c-{accent}` cards. Each card: 3px left accent ribbon, 34×34 logo block, mono channel name eyebrow, big handle in accent colour, dashed-bordered foot with SLA + `↗`. Hover lifts `-3px Y`, switches border + shadow to channel accent.
+3. **Stack badges row** — section eyebrow `$ stack --badges`, followed by a flat row of 12 `.stack-badge` chips (Python · TypeScript · Kubernetes · Terraform · PyTorch · GCP · AWS · Kafka · Airflow · Kubeflow · Datadog · LangChain), each on `#282a36` background with a per-chip accent dot. The Claude prototype renders these with empty `<i></i>` placeholder dots ([app.js:586](design/suryaavala-com/project/app.js)) — `pingLogo()` only ships the 6 contact-channel glyphs ([app.js:516-528](design/suryaavala-com/project/app.js)). **v2 must extend `pingLogo()` (or introduce a parallel `stackLogo()`) with the 12 stack glyphs** so the chips read as proper README-style shields rather than coloured dots. Each glyph rendered at 14×14, `currentColor`, in the chip-accent token.
+4. **Traceroute easter egg** — `.ping-fun` block (dashed border, diagonal-stripe brand-tinted bg) rendering three mono rows — `1 github.com … 1.2ms`, `2 linkedin.com … 2.4ms`, `3 inbox … ~24h business day SLA`.
+
+Reference: [app.js:530-596](design/suryaavala-com/project/app.js).
+
+The full five-channel matrix from [01_design.md §4.6](01_design.md) is preserved; this version adds a sixth channel (Website / `firefox` icon) and re-frames the channels as a "ping → response" latency story.
+
+### 4.7 Contact Modal (overlay, mounts globally)
+
+Triggered by **any** element with `data-open-contact` (in v2 that is the Bold-hero status board CTA, but additional triggers can be added without changing the modal). Closed by:
+
+* the `.cm-close` button,
+* clicking the `.cm-backdrop`,
+* pressing `Esc`,
+* navigating to a different route.
+
+Hotkeys when open: `G | L | E | W | C | S` open the corresponding channel in a new tab (or `window.location.href` for `mailto:`).
+
+Accessibility:
+* `role="dialog" aria-modal="true" aria-labelledby="contact-modal-title"`.
+* On open, `_cmLastFocus` saves `document.activeElement` and focus moves to the first row; on close, focus is restored.
+* `body.is-modal-open` locks scroll.
+
+Reference: [app.js:734-817](design/suryaavala-com/project/app.js), [home-bold.css:438-662](design/suryaavala-com/project/home-bold.css), [index.html:84-102](design/suryaavala-com/project/index.html).
+
+---
+
+## 5. Cross-Cutting Concerns
+
+Inherits §5 of [01_design.md](01_design.md) verbatim — accessibility, SEO, JSON-LD Person schema, Open Graph, CSP. Three small additions specific to v2:
+
+### 5.1 Accessibility (additions)
+
+* **Reduced motion:** Required guards on the typing animation, count-up, status-board flippers, page-in transition, status beacon pulse, modal pop-in, sparkline reveal, and CTA pulse. The Claude bundle's `@media (prefers-reduced-motion: reduce)` block in [styles.css:118-124](design/suryaavala-com/project/styles.css) is the baseline; per-component overrides in [home-bold.css:151-155](design/suryaavala-com/project/home-bold.css) extend it.
+* **Focus-visible:** `outline: 2px solid var(--brand); outline-offset: 2px; border-radius: 3px` on every focusable element. Already token-driven, but must survive any utility-class override.
+* **Modal trap:** The Contact Modal must trap focus within `.cm-panel` while open and restore on close. The Claude prototype implements focus restoration but **not** focus trap — this is a v2 must-fix in the Astro implementation.
+
+### 5.2 CSP
+
+CSP from [01_design.md §5.2](01_design.md) carries over. The `font-src` allowlist already covers `https://fonts.gstatic.com`; the v2 typography additions (Inter italic weights for the Bold title, JetBrains Mono) come from the same origin. No new CSP changes required.
+
+### 5.3 SEO
+
+`<title>` and `<meta description>` lifted from [index.html:6-7](design/suryaavala-com/project/index.html):
+
+* Title: `Surya Avala — Staff ML Engineer & Principal AI Systems Architect`
+* Description: `A decade of making ML systems survive production in healthcare and energy — where the plumbing matters more than the model.`
+
+JSON-LD Person schema unchanged from [01_design.md §5.2](01_design.md).
+
+---
+
+## 6. Data Integrity & Schema
+
+Inherits the Zod-validated Content Collections (§6.1), typed data modules (§6.2), drift detection (§6.3), and build-time validation (§6.4) from [01_design.md](01_design.md). The deltas are listed below — additive only; no breaking changes to v1 schemas.
+
+### 6.x Typed-Data Deltas vs v1
+
+To support the new sparklines, Bold-variant KPI strip, status-board flipper, and contact modal, three typed shapes pick up small additions. Bumping the Zod schema in `/src/data/schemas.ts` is the single point of change.
+
+```typescript
+// Metric — additive: unit + spark for inline sparkline rendering
+export interface Metric {
+  value: string;
+  direction: '↑' | '↓' | '=' | '';   // '=' for "Prod"-style status metrics, '' for none
+  unit: string;                       // NEW — e.g. "%", "+", "x", ""
+  label: string;
+  context: string;
+  methodology?: string;
+  confidenceBound?: ConfidenceBound;
+  accent: string;
+  spark?: number[];                   // NEW — 5–9 normalised values for sparkPath()
+}
+
+// Project — accent renamed to align with token names
+export interface Project {
+  slug: string;
+  title: string;
+  description: string;
+  domain: 'GenAI & Agentic Systems' | 'Systems & Infrastructure' | 'ML & Data Science'
+        | 'Data Engineering & Tooling' | 'Enterprise ML & Document Intelligence';
+  repoUrl: string;
+  tags: string[];
+  accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack';   // NEW — token key, not hex
+  featured: boolean;
+  badge?: 'Featured' | 'Latest';      // RENAMED from badgeLabel for parity with data.js
+}
+
+// Contact — new module, mirrors D.contacts in the Claude bundle
+export interface Contact {
+  channel: string;                    // e.g. "GitHub"
+  handle: string;                     // e.g. "@suryaavala"
+  label: string;                      // mono CTA — e.g. "follow", "connect"
+  url: string;                        // https:// or mailto:
+  accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack';
+  logo: 'github' | 'linkedin' | 'gmail' | 'firefox' | 'coffee' | 'sponsor';
+  sla: string;                        // e.g. "replies < 24h"
+}
+
+// HeroPhrases — new module, drives the typing island
+export interface HeroConfig {
+  name: string;
+  prompt: string;                     // e.g. "~/whoami → surya"
+  headlineSafe: string;               // displayed in Safe variant
+  headlineBold: string;               // displayed in Bold variant
+  subhead: string;
+  tagline: string;
+  phrases: string[];                  // typing cycle
+  industries: string[];
+  stack: { label: string; accent: 'brand'|'status'|'infra'|'impact'|'human'|'stack' }[];
+}
+
+// CompetencyAxis — unchanged from v1; methodology stays required (≥10 chars)
+
+// StackCategory — new module, drives /stack left column
+export interface StackCategory {
+  name: string;
+  accent: 'brand' | 'status' | 'infra' | 'impact' | 'human' | 'stack';
+  items: string[];
+}
+```
+
+Corresponding Zod additions:
+
+```typescript
+const accentEnum = z.enum(['brand', 'status', 'infra', 'impact', 'human', 'stack']);
+
+export const MetricSchema = z.object({
+  value: z.string().min(1),
+  direction: z.enum(['↑', '↓', '=', '']),
+  unit: z.string(),
+  label: z.string().min(10),
+  context: z.string().min(5),
+  methodology: z.string().min(10).optional(),
+  confidenceBound: ConfidenceBoundSchema.optional(),
+  accent: accentEnum,
+  spark: z.array(z.number()).min(5).max(9).optional(),
+});
+
+export const ContactSchema = z.object({
+  channel: z.string().min(1),
+  handle: z.string().min(1),
+  label: z.string().min(1),
+  url: z.string().refine(s => s.startsWith('http') || s.startsWith('mailto:'),
+                         'url must be http(s) or mailto'),
+  accent: accentEnum,
+  logo: z.enum(['github','linkedin','gmail','firefox','coffee','sponsor']),
+  sla: z.string().min(3),
+});
+
+export const StackCategorySchema = z.object({
+  name: z.string().min(1),
+  accent: accentEnum,
+  items: z.array(z.string().min(1)).min(1),
+});
+
+// HeroConfigSchema, ProjectSchema, ExperienceSchema → trivial Zod equivalents
+```
+
+Two notes on the rename / shape changes:
+
+1. **`Project.accent` is now a token key, not a hex.** This decouples projects from the brand-accent swap (§3.5). When the user picks `cyan` as their brand accent, `--brand` flips to `#8be9fd`, and any project with `accent: 'brand'` re-tints automatically. Hard-coded hexes would silently fight the swap.
+2. **`Project.badgeLabel` → `Project.badge`** for parity with [data.js:220-237](design/suryaavala-com/project/data.js). The v1 field is renamed in a single migration commit; CI validation catches any stragglers.
+
+Build-time validation hook (`/scripts/validate-data.ts`) and `prebuild` npm hook are unchanged from [01_design.md §6.4](01_design.md).
+
+### 6.y Build-Time Computed Aggregates
+
+The "By the Numbers" Bento card (§4.1.A row 4) and the `/runtime` "Seven roles. Four regulated industries." sub-line are both **build-time computed** from the typed data, not hard-coded:
+
+```typescript
+// /src/lib/aggregates.ts
+import { experiences } from '../data/experiences';
+import { metrics }     from '../data/metrics';
+import { upstream }    from '../data/upstream';
+
+export const aggregates = {
+  decadeYears:     10,                                                // hard-coded; review annually
+  industryCount:   new Set(experiences.map(e => e.industry)).size,
+  roleCount:       experiences.length,
+  metricCount:     metrics.length,
+  upstreamPRCount: upstream.length,
+} as const;
+```
+
+Each consumer (`homeSafe.astro` for the Bento card, `runtime.astro` for the sub-line) imports `aggregates` and renders the value. CI's existing `lastVerified` staleness check (§6.3) catches stale `decadeYears` once a year — when the date drift exceeds threshold, the lint warning surfaces it.
+
+---
+
+## 7. Open Questions / Risks
+
+* **[RESOLVED]** Two homepage variants vs one: ship both, gate behind dev-only Tweaks panel. Production users land on `safe` by default; users who want the editorial pitch can be linked directly to `/?variant=bold` (a small URL-param hook reads the param once on first paint and writes it to localStorage). See §3.5.
+* **[RESOLVED]** Tailwind vs hand-authored CSS: layered approach — Tailwind for utilities, hand-authored CSS for tokens, animations, OKLAB blends, and component shells. See §2.1.
+* **[RESOLVED]** Mono font swap (Fira Code → JetBrains Mono): JetBrains Mono is the Claude bundle's choice. Adopt it; keep Fira Code as fallback for offline / fontless contexts.
+* **[RESOLVED]** Project `accent` schema (hex vs token key): token key. Keeps the brand-swap honest. See §6.x.
+* **[OPEN]** End-user accent picker: the Tweaks panel is dev-only. If we want users to pick a personal accent, it needs (a) a discoverable UI surface in the nav or footer, (b) a query-param fallback for direct linking, (c) an analytics decision on whether per-user accents should affect the OG image. Decision deferred to post-launch RFC.
+* **[OPEN]** Mobile Bold variant: the editorial typography (`clamp(48px, 8vw, 108px)`) is striking on desktop but reads heavy on phones. Tablet/mobile breakpoints in [home-bold.css](design/suryaavala-com/project/home-bold.css) handle layout collapse, but we should validate the "wow" reads on a phone before defaulting any cohort to Bold.
+* **[OPEN]** Contact modal vs inline `/ping`: with the modal, fewer users will navigate to `/ping`, which weakens the analytics signal for "who reached out". If we care about funnel attribution, add an event hook on each modal channel click before launch.
+

--- a/specs/rfc_end_user_accent_picker.md
+++ b/specs/rfc_end_user_accent_picker.md
@@ -1,4 +1,3 @@
-
 # RFC: End-User Accent Picker for `suryaavala.com`
 
 **Document Owner:** Staff Software Engineer / TPM
@@ -21,18 +20,18 @@
 
 The site ships with a **dev-only Tweaks panel** ([02_design.md §3.5](02_design.md), [app.js:700–732](design/suryaavala-com/project/app.js)) bottom-right, fixed-positioned, 260px wide. It exposes two controls:
 
-| Control | Storage Key | Values |
-|---|---|---|
-| Homepage variant | `localStorage["sa-home-variant"]` | `safe` \| `bold` |
-| Brand accent | `localStorage["sa-accent"]` | `purple` \| `cyan` \| `green` \| `orange` \| `pink` |
+| Control          | Storage Key                       | Values                                              |
+| ---------------- | --------------------------------- | --------------------------------------------------- |
+| Homepage variant | `localStorage["sa-home-variant"]` | `safe` \| `bold`                                    |
+| Brand accent     | `localStorage["sa-accent"]`       | `purple` \| `cyan` \| `green` \| `orange` \| `pink` |
 
 The accent control mutates `--brand` and `--brand-body` via `applyAccent()` ([app.js:41–46](design/suryaavala-com/project/app.js)):
 
 ```javascript
 function applyAccent(k) {
   const a = ACCENT_MAP[k] || ACCENT_MAP.purple;
-  document.documentElement.style.setProperty("--brand", a.brand);
-  document.documentElement.style.setProperty("--brand-body", a.body);
+  document.documentElement.style.setProperty('--brand', a.brand);
+  document.documentElement.style.setProperty('--brand-body', a.body);
 }
 ```
 
@@ -40,13 +39,13 @@ Because every component that renders in the brand colour reads `var(--brand)` (H
 
 The five preset `(brand, brand-body)` pairs (canonical reference, copied verbatim from [app.js:34–40](design/suryaavala-com/project/app.js)):
 
-| Key      | `--brand`  | `--brand-body` |
-|----------|------------|----------------|
-| `purple` | `#bd93f9`  | `#c4a0ff`      |
-| `cyan`   | `#8be9fd`  | `#b4f0ff`      |
-| `green`  | `#50fa7b`  | `#7effa0`      |
-| `orange` | `#ffb86c`  | `#ffce99`      |
-| `pink`   | `#ff79c6`  | `#ffa2d6`      |
+| Key      | `--brand` | `--brand-body` |
+| -------- | --------- | -------------- |
+| `purple` | `#bd93f9` | `#c4a0ff`      |
+| `cyan`   | `#8be9fd` | `#b4f0ff`      |
+| `green`  | `#50fa7b` | `#7effa0`      |
+| `orange` | `#ffb86c` | `#ffce99`      |
+| `pink`   | `#ff79c6` | `#ffa2d6`      |
 
 The panel itself is **gated** by a `parent.postMessage({type: "__activate_edit_mode"})` event from the Claude Design preview iframe ([app.js:721–727](design/suryaavala-com/project/app.js)). Because GH Pages → Cloudflare never sends that message, production users cannot reach it. The panel and its swatches are inert in the production DOM (CSS sets `.tweaks { display: none; }` until `.open` is added — [styles.css:409, 413](design/suryaavala-com/project/styles.css)).
 
@@ -62,9 +61,9 @@ Three weak forces pull in this direction; one strong force pushes back.
 
 **Pushes back:**
 
-1. **Design integrity.** The whole point of curated accents is that the canonical `purple` carries identity. Letting users freely pick risks fragmenting "what the site looks like" in screenshots and discussions. We *deliberately* ship five presets — not a colour wheel — to hold the line on cohesion.
+1. **Design integrity.** The whole point of curated accents is that the canonical `purple` carries identity. Letting users freely pick risks fragmenting "what the site looks like" in screenshots and discussions. We _deliberately_ ship five presets — not a colour wheel — to hold the line on cohesion.
 2. **Analytics noise.** Per-session accent state pollutes session recordings and heat-map composites. Mitigated by tracking the dimension explicitly (see §9), not by avoiding it.
-3. **OG image complexity.** The default GH Pages/Cloudflare deployment pipeline ships a *static* OG asset. Per-accent OGs cost build time, edge compute, or both. See §6.
+3. **OG image complexity.** The default GH Pages/Cloudflare deployment pipeline ships a _static_ OG asset. Per-accent OGs cost build time, edge compute, or both. See §6.
 
 The remit of this RFC is to land **(a)** a discoverability surface, **(b)** a query-param fallback, and **(c)** an OG-image policy — opinionated recommendations, not just option enumeration.
 
@@ -74,45 +73,45 @@ The remit of this RFC is to land **(a)** a discoverability surface, **(b)** a qu
 
 ### 2.1 Goals
 
-* **G1.** Ship a production-visible UI surface that lets users pick any of the **five existing presets** and persist their choice across navigations and reloads.
-* **G2.** Ship a `?accent=<key>` URL query-param that produces the same end state as a manual pick — usable for direct linking, share buttons, and QR codes.
-* **G3.** Resolve the OG-image question with one decision and one rollback path.
-* **G4.** Coexist with the dev-only Tweaks panel from [02_design.md §3.5](02_design.md). Both surfaces write to the same `localStorage["sa-accent"]` key; the dev panel remains dev-only.
-* **G5.** Preserve all accessibility properties of the v2 design — WCAG AA contrast on every preset, focus-visible behaviour on the new control, `prefers-reduced-motion` handling on the swap transition.
-* **G6.** Add zero new external dependencies. Implementation is hand-authored Astro + Svelte using existing tokens.
+- **G1.** Ship a production-visible UI surface that lets users pick any of the **five existing presets** and persist their choice across navigations and reloads.
+- **G2.** Ship a `?accent=<key>` URL query-param that produces the same end state as a manual pick — usable for direct linking, share buttons, and QR codes.
+- **G3.** Resolve the OG-image question with one decision and one rollback path.
+- **G4.** Coexist with the dev-only Tweaks panel from [02_design.md §3.5](02_design.md). Both surfaces write to the same `localStorage["sa-accent"]` key; the dev panel remains dev-only.
+- **G5.** Preserve all accessibility properties of the v2 design — WCAG AA contrast on every preset, focus-visible behaviour on the new control, `prefers-reduced-motion` handling on the swap transition.
+- **G6.** Add zero new external dependencies. Implementation is hand-authored Astro + Svelte using existing tokens.
 
 ### 2.2 Non-Goals
 
-* **NG1.** No full theme builder. No colour-wheel input, no hex entry, no per-channel HSL sliders.
-* **NG2.** No new accent presets. Five only. If a sixth preset is ever needed, it gets its own RFC and a contrast audit ([01_design.md §3.1](01_design.md) WCAG note).
-* **NG3.** No per-page accent overrides. The accent is **site-wide and per-user**, not per-page or per-route. A user who picked `cyan` sees `cyan` everywhere — including `/runtime`, `/stack`, `/notes`, etc.
-* **NG4.** No theme builder for the **homepage variant** (`safe`/`bold`). That stays gated to the dev panel for v2.1. The variant decision is editorial; the accent decision is cosmetic.
-* **NG5.** No change to the dev Tweaks panel UX, layout, or activation protocol. This RFC adds a *parallel* user surface, not a replacement.
-* **NG6.** No server-side personalisation, no auth, no per-user persistence beyond `localStorage`. A user clearing site data loses their preference, by design.
-* **NG7.** No cookie banner. `localStorage["sa-accent"]` is a strictly-necessary functional preference (UI personalisation, no PII, no tracking) — same legal posture as the existing `sa-theme` and `sa-home-variant` keys.
+- **NG1.** No full theme builder. No colour-wheel input, no hex entry, no per-channel HSL sliders.
+- **NG2.** No new accent presets. Five only. If a sixth preset is ever needed, it gets its own RFC and a contrast audit ([01_design.md §3.1](01_design.md) WCAG note).
+- **NG3.** No per-page accent overrides. The accent is **site-wide and per-user**, not per-page or per-route. A user who picked `cyan` sees `cyan` everywhere — including `/runtime`, `/stack`, `/notes`, etc.
+- **NG4.** No theme builder for the **homepage variant** (`safe`/`bold`). That stays gated to the dev panel for v2.1. The variant decision is editorial; the accent decision is cosmetic.
+- **NG5.** No change to the dev Tweaks panel UX, layout, or activation protocol. This RFC adds a _parallel_ user surface, not a replacement.
+- **NG6.** No server-side personalisation, no auth, no per-user persistence beyond `localStorage`. A user clearing site data loses their preference, by design.
+- **NG7.** No cookie banner. `localStorage["sa-accent"]` is a strictly-necessary functional preference (UI personalisation, no PII, no tracking) — same legal posture as the existing `sa-theme` and `sa-home-variant` keys.
 
 ---
 
 ## 3. Design Options for (a) — Discoverability Surface
 
-We need *one* place users can find the picker. Five candidates were considered:
+We need _one_ place users can find the picker. Five candidates were considered:
 
-| # | Option | Discoverability | Visual noise | Implementation cost | Mobile fit | Notes |
-|---|---|---|---|---|---|---|
-| 3.1 | **Nav-mounted swatch row** (5 dots inline next to theme toggle) | High | Medium-high | Low | Poor — eats sticky-nav width budget | Sticky nav is already dense (mono brand mark, slash-prefixed links, theme toggle, Open-to-Work CTA — [02_design.md §3.2 Glass Nav](02_design.md)). Adding 5 swatches at ≤1024px collides with the CTA, which already drops out below 1024px. |
-| 3.2 | **Footer-mounted picker** (5 swatches in a `.footer` row) | Low–medium | Low | Low | Good | Below the fold for first-paint. Discoverable for engaged scrollers; invisible to bouncers. Cheap. |
-| 3.3 | **Dedicated `/preferences` route** | Very low | Zero on every other page | Medium (one new route, page chrome, nav entry) | Good | Bloats site map (currently 6 routes — [02_design.md §3.3](02_design.md)). Discoverability requires a nav entry, looping back to 3.1's problem. Overkill for one toggle and five swatches. |
-| 3.4 | **Hidden-until-keypress** (`?` opens a tray) | Very low for non-keyboard users | Zero | Low | Bad — no on-screen affordance on touch | Cute easter egg. Unsuitable as the *primary* surface; could supplement another. |
-| 3.5 | **Footer command palette** (`Cmd-K` style, channels + accents + theme) | Low–medium | Zero on first paint | High | Awkward (requires pinned trigger) | Over-engineered for one decision. Worth reconsidering when the surface count exceeds three. |
+| #   | Option                                                                 | Discoverability                 | Visual noise             | Implementation cost                            | Mobile fit                             | Notes                                                                                                                                                                                                                                        |
+| --- | ---------------------------------------------------------------------- | ------------------------------- | ------------------------ | ---------------------------------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 3.1 | **Nav-mounted swatch row** (5 dots inline next to theme toggle)        | High                            | Medium-high              | Low                                            | Poor — eats sticky-nav width budget    | Sticky nav is already dense (mono brand mark, slash-prefixed links, theme toggle, Open-to-Work CTA — [02_design.md §3.2 Glass Nav](02_design.md)). Adding 5 swatches at ≤1024px collides with the CTA, which already drops out below 1024px. |
+| 3.2 | **Footer-mounted picker** (5 swatches in a `.footer` row)              | Low–medium                      | Low                      | Low                                            | Good                                   | Below the fold for first-paint. Discoverable for engaged scrollers; invisible to bouncers. Cheap.                                                                                                                                            |
+| 3.3 | **Dedicated `/preferences` route**                                     | Very low                        | Zero on every other page | Medium (one new route, page chrome, nav entry) | Good                                   | Bloats site map (currently 6 routes — [02_design.md §3.3](02_design.md)). Discoverability requires a nav entry, looping back to 3.1's problem. Overkill for one toggle and five swatches.                                                    |
+| 3.4 | **Hidden-until-keypress** (`?` opens a tray)                           | Very low for non-keyboard users | Zero                     | Low                                            | Bad — no on-screen affordance on touch | Cute easter egg. Unsuitable as the _primary_ surface; could supplement another.                                                                                                                                                              |
+| 3.5 | **Footer command palette** (`Cmd-K` style, channels + accents + theme) | Low–medium                      | Zero on first paint      | High                                           | Awkward (requires pinned trigger)      | Over-engineered for one decision. Worth reconsidering when the surface count exceeds three.                                                                                                                                                  |
 
 ### 3.6 Recommendation: **Footer-mounted picker (3.2), with a keyboard-shortcut accelerator (3.4) layered on top**
 
 Rationale:
 
-* **Honesty about who uses it.** Users who care about theming will scroll for it; users who don't shouldn't carry the cognitive cost in the nav. The footer is the conventional home for preferences (cf. dev.to, Stripe Docs, Tailwind).
-* **Nav stays clean.** The Glass Nav row is already operating at its visual budget — five 24px swatches in there would force the Open-to-Work CTA off the layout earlier than 1024px, hurting the conversion signal.
-* **Power-user accelerator costs ~10 LOC.** Pressing `?` (or `Shift-/`) scrolls smoothly to the footer picker and focuses the first swatch. This makes the feature feel "discovered" without making it loud. It is an accessibility win for keyboard users and a personality win for the developer-native audience.
-* **Mobile parity.** The footer is reachable on mobile by definition (it's where you end up). The nav option has no graceful fallback on `≤640px` — mobile users would get no picker at all.
+- **Honesty about who uses it.** Users who care about theming will scroll for it; users who don't shouldn't carry the cognitive cost in the nav. The footer is the conventional home for preferences (cf. dev.to, Stripe Docs, Tailwind).
+- **Nav stays clean.** The Glass Nav row is already operating at its visual budget — five 24px swatches in there would force the Open-to-Work CTA off the layout earlier than 1024px, hurting the conversion signal.
+- **Power-user accelerator costs ~10 LOC.** Pressing `?` (or `Shift-/`) scrolls smoothly to the footer picker and focuses the first swatch. This makes the feature feel "discovered" without making it loud. It is an accessibility win for keyboard users and a personality win for the developer-native audience.
+- **Mobile parity.** The footer is reachable on mobile by definition (it's where you end up). The nav option has no graceful fallback on `≤640px` — mobile users would get no picker at all.
 
 ### 3.7 Visual & layout sketch (footer picker)
 
@@ -127,16 +126,16 @@ Rationale:
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
-* Five 24×24px swatches identical in dimension/markup to the existing dev-panel `.swatches button` ([styles.css:455–464](design/suryaavala-com/project/styles.css)) — reuses the CSS, no new tokens.
-* The active swatch wears the same `.on` class (border `var(--text)` at 2px) used by the dev panel ([styles.css:464](design/suryaavala-com/project/styles.css)). This keeps the visual contract consistent across both surfaces.
-* `aria-label` per swatch: `"Set accent to {name}"`. The active swatch additionally carries `aria-pressed="true"`.
-* The "press `?` to jump here" hint is shown only on viewports ≥1024px and only on first session (gated by a `localStorage["sa-accent-hint-dismissed"]` flag flipped after first interaction or 5s view).
+- Five 24×24px swatches identical in dimension/markup to the existing dev-panel `.swatches button` ([styles.css:455–464](design/suryaavala-com/project/styles.css)) — reuses the CSS, no new tokens.
+- The active swatch wears the same `.on` class (border `var(--text)` at 2px) used by the dev panel ([styles.css:464](design/suryaavala-com/project/styles.css)). This keeps the visual contract consistent across both surfaces.
+- `aria-label` per swatch: `"Set accent to {name}"`. The active swatch additionally carries `aria-pressed="true"`.
+- The "press `?` to jump here" hint is shown only on viewports ≥1024px and only on first session (gated by a `localStorage["sa-accent-hint-dismissed"]` flag flipped after first interaction or 5s view).
 
 ### 3.8 What the footer picker does NOT do
 
-* It does **not** let users change the homepage variant. That stays dev-only.
-* It does **not** let users enter a custom hex.
-* It does **not** announce itself with a banner, toast, or first-visit modal. Discovery is via scroll, share-link param, or `?` keypress.
+- It does **not** let users change the homepage variant. That stays dev-only.
+- It does **not** let users enter a custom hex.
+- It does **not** announce itself with a banner, toast, or first-visit modal. Discovery is via scroll, share-link param, or `?` keypress.
 
 ---
 
@@ -146,19 +145,19 @@ Rationale:
 
 Three candidate shapes:
 
-| Shape | Pros | Cons |
-|---|---|---|
-| `?accent=cyan` | Self-describing, matches preset key namespace from [app.js:34–40](design/suryaavala-com/project/app.js), grep-friendly in analytics | Only handles accent; we may want similar mechanics for theme later |
-| `?theme=cyan` | Reuses the `theme` mental model | Conflates light/dark theme with accent — the site already has a `sa-theme` storage key that means light vs dark. Collision risk. |
-| `?ui=cyan-dark` | Compact, multi-axis-ready | Opaque, hard to share verbally, requires a parser |
+| Shape           | Pros                                                                                                                                | Cons                                                                                                                             |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `?accent=cyan`  | Self-describing, matches preset key namespace from [app.js:34–40](design/suryaavala-com/project/app.js), grep-friendly in analytics | Only handles accent; we may want similar mechanics for theme later                                                               |
+| `?theme=cyan`   | Reuses the `theme` mental model                                                                                                     | Conflates light/dark theme with accent — the site already has a `sa-theme` storage key that means light vs dark. Collision risk. |
+| `?ui=cyan-dark` | Compact, multi-axis-ready                                                                                                           | Opaque, hard to share verbally, requires a parser                                                                                |
 
 **Recommendation: `?accent=<key>`.** Direct mapping to `ACCENT_MAP` keys, no parsing, no collision with the existing `sa-theme` semantic. If later we need a light/dark override via URL, it gets a separate `?theme=light|dark` param.
 
 ### 4.2 Validation
 
-* Allowed values: exactly the five keys in `ACCENT_MAP` — `purple` | `cyan` | `green` | `orange` | `pink`.
-* Unknown values are **silently ignored** (not redirected, not error-toasted). Defence against share-link bit-rot and link-shortener mutilation.
-* Case-insensitive on read (`?accent=CYAN` works); we lowercase before lookup.
+- Allowed values: exactly the five keys in `ACCENT_MAP` — `purple` | `cyan` | `green` | `orange` | `pink`.
+- Unknown values are **silently ignored** (not redirected, not error-toasted). Defence against share-link bit-rot and link-shortener mutilation.
+- Case-insensitive on read (`?accent=CYAN` works); we lowercase before lookup.
 
 ### 4.3 Precedence
 
@@ -166,11 +165,11 @@ The interesting question: what wins between the URL param, `localStorage`, and t
 
 Three candidate precedence rules:
 
-| Rule | Behaviour | Pros | Cons |
-|---|---|---|---|
-| **(A) URL > localStorage > default**, consume-and-store | First load with `?accent=cyan` writes `cyan` to localStorage and strips the param from the URL via `history.replaceState`. Subsequent navigations see `cyan` in storage. | Maximum continuity — share link instantly becomes "your" theme. Clean URL after first paint. | Surprise: a user who *had* `pink` set, then clicked a `?accent=cyan` link, has now silently lost their preference. |
-| **(B) URL > localStorage > default**, ephemeral (read every load, never stored) | The param wins for that single page-view; on next navigation without the param, localStorage (or default) takes over. | No silent override of saved preferences. Predictable. | Sharing a link doesn't give the recipient a *persistent* accent. They have to use the picker themselves to keep it. |
-| **(C) localStorage > URL > default** | If the user has *ever* picked an accent, that wins forever. Param only seeds the *first* visit. | Preserves "I made a choice." Shared links work for fresh visitors. | Returning visitors with a stale localStorage value get a worse share-link experience than expected. |
+| Rule                                                                            | Behaviour                                                                                                                                                                | Pros                                                                                         | Cons                                                                                                                |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **(A) URL > localStorage > default**, consume-and-store                         | First load with `?accent=cyan` writes `cyan` to localStorage and strips the param from the URL via `history.replaceState`. Subsequent navigations see `cyan` in storage. | Maximum continuity — share link instantly becomes "your" theme. Clean URL after first paint. | Surprise: a user who _had_ `pink` set, then clicked a `?accent=cyan` link, has now silently lost their preference.  |
+| **(B) URL > localStorage > default**, ephemeral (read every load, never stored) | The param wins for that single page-view; on next navigation without the param, localStorage (or default) takes over.                                                    | No silent override of saved preferences. Predictable.                                        | Sharing a link doesn't give the recipient a _persistent_ accent. They have to use the picker themselves to keep it. |
+| **(C) localStorage > URL > default**                                            | If the user has _ever_ picked an accent, that wins forever. Param only seeds the _first_ visit.                                                                          | Preserves "I made a choice." Shared links work for fresh visitors.                           | Returning visitors with a stale localStorage value get a worse share-link experience than expected.                 |
 
 ### 4.4 Recommendation: Hybrid of (A) and (B) — **URL wins for the session; we offer to persist**
 
@@ -178,21 +177,21 @@ The mechanic:
 
 1. On first paint, read `?accent=<k>` from the URL.
 2. If `<k>` is valid:
-   * Apply it immediately via `applyAccent(k)` ([app.js:41–46](design/suryaavala-com/project/app.js)).
-   * Strip the param from the URL via `history.replaceState` (clean address bar, clean copy-paste, OG re-share continues to work because the param is consumed *after* the OG fetch).
-   * **Do not write it to localStorage.** The session state diverges from the persisted state — exactly as in option (B).
+   - Apply it immediately via `applyAccent(k)` ([app.js:41–46](design/suryaavala-com/project/app.js)).
+   - Strip the param from the URL via `history.replaceState` (clean address bar, clean copy-paste, OG re-share continues to work because the param is consumed _after_ the OG fetch).
+   - **Do not write it to localStorage.** The session state diverges from the persisted state — exactly as in option (B).
 3. Render a small, dismissible footer toast: `"Trying out cyan. Keep this accent?  [Keep]  [Dismiss]"`.
-   * `Keep` → write `localStorage["sa-accent"] = k`, remove the toast.
-   * `Dismiss` → revert to the localStorage value (or default `purple`) on next navigation, remove the toast.
-   * Auto-dismiss after 12s (no implicit save — silence means revert).
+   - `Keep` → write `localStorage["sa-accent"] = k`, remove the toast.
+   - `Dismiss` → revert to the localStorage value (or default `purple`) on next navigation, remove the toast.
+   - Auto-dismiss after 12s (no implicit save — silence means revert).
 4. If `?accent=<k>` is invalid or absent, behave normally: read `localStorage["sa-accent"]` or fall back to `purple`.
 
 This is option (B) with a one-tap upgrade to (A). It is the only rule that:
 
-* Lets share-links instantly recolour the destination (G2).
-* Never silently overwrites a user's saved choice (Goal G6 spirit).
-* Keeps the URL clean for re-share / SEO.
-* Gives the recipient explicit consent before persistence.
+- Lets share-links instantly recolour the destination (G2).
+- Never silently overwrites a user's saved choice (Goal G6 spirit).
+- Keeps the URL clean for re-share / SEO.
+- Gives the recipient explicit consent before persistence.
 
 The toast is a Svelte island, accent-tinted to the param-supplied colour (so the recipient sees the proposed colour on the toast itself). It uses the same focus-trap and keyboard-dismiss (`Esc`) primitives as the Contact Modal ([02_design.md §3.2 Contact Modal row](02_design.md), [app.js:734–817](design/suryaavala-com/project/app.js)) — minus the focus trap (toast is non-modal).
 
@@ -210,28 +209,28 @@ The Open Graph image is a single static asset shipped from `/public/og.png` (120
 
 Three candidate strategies:
 
-| Option | Build-time cost | Runtime cost | SEO impact | Social-share fidelity | Operational complexity |
-|---|---|---|---|---|---|
-| **(i) One canonical purple OG** | 0 | 0 | None (canonical OG cached by Facebook, LinkedIn, Twitter, Slack) | Low: share `?accent=cyan`, recipient sees purple OG, then a cyan site | None |
-| **(ii) Five static OGs, picked via param** | 5× build time for OG generation, 5× asset weight in `/public` | None (URL maps to file) | Slight: each accent has its own canonical OG URL — Twitter/Slack will cache them independently | High: share matches site colour | Medium: build script must produce 5 OGs and `<meta og:image>` must be set per param at SSR time |
-| **(iii) Edge-generated OG via Cloudflare Workers** | 0 (no static assets) | ~50–200ms cold, free tier covers <100k req/day | Higher: every request to `/og.png?accent=cyan` is a Worker invocation; URL-cache discipline is essential | High: instant per-accent OGs, plus future variant axes (theme, etc.) | High: introduces a Worker to a previously zero-runtime stack — violates [02_design.md §2.2](02_design.md) "no runtime fetch" principle |
+| Option                                             | Build-time cost                                               | Runtime cost                                   | SEO impact                                                                                               | Social-share fidelity                                                 | Operational complexity                                                                                                                 |
+| -------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **(i) One canonical purple OG**                    | 0                                                             | 0                                              | None (canonical OG cached by Facebook, LinkedIn, Twitter, Slack)                                         | Low: share `?accent=cyan`, recipient sees purple OG, then a cyan site | None                                                                                                                                   |
+| **(ii) Five static OGs, picked via param**         | 5× build time for OG generation, 5× asset weight in `/public` | None (URL maps to file)                        | Slight: each accent has its own canonical OG URL — Twitter/Slack will cache them independently           | High: share matches site colour                                       | Medium: build script must produce 5 OGs and `<meta og:image>` must be set per param at SSR time                                        |
+| **(iii) Edge-generated OG via Cloudflare Workers** | 0 (no static assets)                                          | ~50–200ms cold, free tier covers <100k req/day | Higher: every request to `/og.png?accent=cyan` is a Worker invocation; URL-cache discipline is essential | High: instant per-accent OGs, plus future variant axes (theme, etc.)  | High: introduces a Worker to a previously zero-runtime stack — violates [02_design.md §2.2](02_design.md) "no runtime fetch" principle |
 
 ### 5.2 Recommendation: **(i) One canonical purple OG — for v2.1**
 
 Rationale, in order of weight:
 
-1. **Brand cohesion is the *whole point* of curating five presets.** `purple` is identity. The OG is the identity-bearing surface of every share. Letting a user repaint the OG at will is a category mistake — it converts the site's visual brand into per-user marketing collateral. The OG should always say "this is suryaavala.com," not "this is suryaavala.com as filtered by a stranger's preferences."
-2. **Cost vs benefit.** Option (ii) ships 5× the OG asset weight and complicates the SSR pipeline for an effect most users will never notice. Option (iii) introduces a Worker — runtime infrastructure — into a stack whose explicit non-goal in [02_design.md §2.2](02_design.md) is *no runtime fetch*. Both costs are real; the benefit is "the share image matches the site for users who set a custom accent."
+1. **Brand cohesion is the _whole point_ of curating five presets.** `purple` is identity. The OG is the identity-bearing surface of every share. Letting a user repaint the OG at will is a category mistake — it converts the site's visual brand into per-user marketing collateral. The OG should always say "this is suryaavala.com," not "this is suryaavala.com as filtered by a stranger's preferences."
+2. **Cost vs benefit.** Option (ii) ships 5× the OG asset weight and complicates the SSR pipeline for an effect most users will never notice. Option (iii) introduces a Worker — runtime infrastructure — into a stack whose explicit non-goal in [02_design.md §2.2](02_design.md) is _no runtime fetch_. Both costs are real; the benefit is "the share image matches the site for users who set a custom accent."
 3. **The hybrid precedence rule (§4.4) absorbs the inconsistency cleanly.** When a recipient clicks a `?accent=cyan` link:
-   * The OG that pulled them in was purple (canonical brand).
-   * The site they land on is cyan (because the URL says so).
-   * The toast asks: "Keep this accent?" — converting the discrepancy into an *explanation* rather than a glitch.
+   - The OG that pulled them in was purple (canonical brand).
+   - The site they land on is cyan (because the URL says so).
+   - The toast asks: "Keep this accent?" — converting the discrepancy into an _explanation_ rather than a glitch.
 4. **SEO discipline.** A single canonical OG keeps Twitter card / LinkedIn / Slack unfurl caches consistent. Multi-OG strategies have a long history of cache-coherence bugs (Slack caches by URL, not by query-param; Twitter dedupes aggressively). Not worth it.
-5. **Reversibility.** If post-launch analytics show >5% of sessions arriving via `?accent=` URLs *and* the brand team requests per-accent OGs, we can ship option (ii) as a follow-on RFC. Option (iii) remains the long-tail option if/when we add an OG that is itself dynamic for other reasons (per-page, per-note, per-role).
+5. **Reversibility.** If post-launch analytics show >5% of sessions arriving via `?accent=` URLs _and_ the brand team requests per-accent OGs, we can ship option (ii) as a follow-on RFC. Option (iii) remains the long-tail option if/when we add an OG that is itself dynamic for other reasons (per-page, per-note, per-role).
 
 ### 5.3 Out of scope for this RFC, flagged for the next one
 
-* Per-page OG variations (e.g. `/runtime` showing the timeline, `/stack` showing the radar chart). Currently every route uses the homepage OG. That is an editorial gap unrelated to accent. If addressed in a future RFC, edge-generation (option iii) becomes the obvious vehicle.
+- Per-page OG variations (e.g. `/runtime` showing the timeline, `/stack` showing the radar chart). Currently every route uses the homepage OG. That is an editorial gap unrelated to accent. If addressed in a future RFC, edge-generation (option iii) becomes the obvious vehicle.
 
 ---
 
@@ -239,15 +238,15 @@ Rationale, in order of weight:
 
 ### 6.1 Files touched
 
-| File | Change type | Notes |
-|---|---|---|
-| `/src/components/AccentPicker.svelte` | **NEW** Svelte island | Footer picker UI |
-| `/src/components/AccentToast.svelte` | **NEW** Svelte island | "Keep this accent?" prompt |
-| `/src/lib/accent.ts` | **NEW** TS module | `ACCENT_MAP`, `applyAccent`, `readAccentParam`, `applyFromContext` |
-| `/src/layouts/Layout.astro` | EDIT | Mount `<AccentPicker>` in footer; mount `<AccentToast>` once at root |
-| `/src/styles/tokens.css` | UNCHANGED | No new tokens — reuses `--brand`, `--brand-body` |
-| `/src/data/accent.ts` (or co-located) | NEW const | Single source of truth for `ACCENT_MAP` — *replaces the duplicated map in [app.js:34–40](design/suryaavala-com/project/app.js)* once we port to Astro |
-| `tweaks/Tweaks.svelte` (existing dev panel) | EDIT (1 LOC) | Import `ACCENT_MAP` from `/src/lib/accent.ts` instead of duplicating it |
+| File                                        | Change type           | Notes                                                                                                                                                 |
+| ------------------------------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/src/components/AccentPicker.svelte`       | **NEW** Svelte island | Footer picker UI                                                                                                                                      |
+| `/src/components/AccentToast.svelte`        | **NEW** Svelte island | "Keep this accent?" prompt                                                                                                                            |
+| `/src/lib/accent.ts`                        | **NEW** TS module     | `ACCENT_MAP`, `applyAccent`, `readAccentParam`, `applyFromContext`                                                                                    |
+| `/src/layouts/Layout.astro`                 | EDIT                  | Mount `<AccentPicker>` in footer; mount `<AccentToast>` once at root                                                                                  |
+| `/src/styles/tokens.css`                    | UNCHANGED             | No new tokens — reuses `--brand`, `--brand-body`                                                                                                      |
+| `/src/data/accent.ts` (or co-located)       | NEW const             | Single source of truth for `ACCENT_MAP` — _replaces the duplicated map in [app.js:34–40](design/suryaavala-com/project/app.js)_ once we port to Astro |
+| `tweaks/Tweaks.svelte` (existing dev panel) | EDIT (1 LOC)          | Import `ACCENT_MAP` from `/src/lib/accent.ts` instead of duplicating it                                                                               |
 
 The dev Tweaks panel and the user picker share the **same** `ACCENT_MAP` constant, the **same** `applyAccent()` function, and the **same** `localStorage["sa-accent"]` key. A change to any preset's hex automatically propagates to both surfaces. This is the load-bearing migration commitment of this RFC.
 
@@ -259,10 +258,10 @@ export type AccentKey = 'purple' | 'cyan' | 'green' | 'orange' | 'pink';
 
 export const ACCENT_MAP: Record<AccentKey, { brand: string; body: string }> = {
   purple: { brand: '#bd93f9', body: '#c4a0ff' },
-  cyan:   { brand: '#8be9fd', body: '#b4f0ff' },
-  green:  { brand: '#50fa7b', body: '#7effa0' },
+  cyan: { brand: '#8be9fd', body: '#b4f0ff' },
+  green: { brand: '#50fa7b', body: '#7effa0' },
   orange: { brand: '#ffb86c', body: '#ffce99' },
-  pink:   { brand: '#ff79c6', body: '#ffa2d6' },
+  pink: { brand: '#ff79c6', body: '#ffa2d6' }
 };
 
 export const ACCENT_KEYS = Object.keys(ACCENT_MAP) as AccentKey[];
@@ -275,7 +274,7 @@ export function isAccentKey(s: unknown): s is AccentKey {
 
 export function applyAccent(k: AccentKey): void {
   const a = ACCENT_MAP[k];
-  document.documentElement.style.setProperty('--brand',      a.brand);
+  document.documentElement.style.setProperty('--brand', a.brand);
   document.documentElement.style.setProperty('--brand-body', a.body);
 }
 
@@ -291,12 +290,16 @@ export function readStoredAccent(): AccentKey {
     const v = localStorage.getItem(STORAGE_KEY);
     return isAccentKey(v) ? (v as AccentKey) : DEFAULT_ACCENT;
   } catch {
-    return DEFAULT_ACCENT;            // SSR / private mode / disabled storage
+    return DEFAULT_ACCENT; // SSR / private mode / disabled storage
   }
 }
 
 export function persistAccent(k: AccentKey): void {
-  try { localStorage.setItem(STORAGE_KEY, k); } catch { /* swallow */ }
+  try {
+    localStorage.setItem(STORAGE_KEY, k);
+  } catch {
+    /* swallow */
+  }
 }
 
 /**
@@ -327,24 +330,26 @@ To prevent a flash of purple before the swap runs (FOUC), `bootAccent()` is call
 
 ```html
 <script is:inline>
-  (function() {
+  (function () {
     try {
       var url = new URL(location.href);
       var raw = url.searchParams.get('accent');
       var MAP = {
         purple: { brand: '#bd93f9', body: '#c4a0ff' },
-        cyan:   { brand: '#8be9fd', body: '#b4f0ff' },
-        green:  { brand: '#50fa7b', body: '#7effa0' },
+        cyan: { brand: '#8be9fd', body: '#b4f0ff' },
+        green: { brand: '#50fa7b', body: '#7effa0' },
         orange: { brand: '#ffb86c', body: '#ffce99' },
-        pink:   { brand: '#ff79c6', body: '#ffa2d6' },
+        pink: { brand: '#ff79c6', body: '#ffa2d6' }
       };
-      var k = raw && MAP[raw.toLowerCase()] ? raw.toLowerCase()
-              : (localStorage.getItem('sa-accent') || 'purple');
+      var k =
+        raw && MAP[raw.toLowerCase()]
+          ? raw.toLowerCase()
+          : localStorage.getItem('sa-accent') || 'purple';
       if (MAP[k]) {
-        document.documentElement.style.setProperty('--brand',      MAP[k].brand);
+        document.documentElement.style.setProperty('--brand', MAP[k].brand);
         document.documentElement.style.setProperty('--brand-body', MAP[k].body);
       }
-    } catch(e) {}
+    } catch (e) {}
   })();
 </script>
 ```
@@ -356,8 +361,13 @@ This duplicates the `ACCENT_MAP` constant once (intentionally) so the head-scrip
 ```svelte
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { ACCENT_KEYS, ACCENT_MAP, applyAccent, persistAccent, readStoredAccent }
-    from '../lib/accent';
+  import {
+    ACCENT_KEYS,
+    ACCENT_MAP,
+    applyAccent,
+    persistAccent,
+    readStoredAccent
+  } from '../lib/accent';
   import type { AccentKey } from '../lib/accent';
 
   let active: AccentKey = 'purple';
@@ -368,7 +378,7 @@ This duplicates the `ACCENT_MAP` constant once (intentionally) so the head-scrip
     const onKey = (e: KeyboardEvent) => {
       if (e.key === '?' && !e.target?.matches?.('input,textarea,[contenteditable]')) {
         document.getElementById('accent-picker')?.scrollIntoView({ behavior: 'smooth' });
-        (document.querySelector<HTMLButtonElement>('#accent-picker button'))?.focus();
+        document.querySelector<HTMLButtonElement>('#accent-picker button')?.focus();
       }
     };
     window.addEventListener('keydown', onKey);
@@ -380,8 +390,9 @@ This duplicates the `ACCENT_MAP` constant once (intentionally) so the head-scrip
     applyAccent(k);
     persistAccent(k);
     // Emit analytics — see §9.
-    window.dispatchEvent(new CustomEvent('accent:changed',
-      { detail: { accent: k, source: 'picker' } }));
+    window.dispatchEvent(
+      new CustomEvent('accent:changed', { detail: { accent: k, source: 'picker' } })
+    );
   }
 </script>
 
@@ -406,11 +417,11 @@ The styles reuse `.swatches` and `.swatches button` from [styles.css:455–464](
 
 The function body at [app.js:41–46](design/suryaavala-com/project/app.js) is reused **verbatim** in `/src/lib/accent.ts`. The only behavioural delta is the addition of:
 
-* `readAccentParam(url)` — new
-* `bootAccent()` — new
-* The pre-FOUC `<script is:inline>` block — new
+- `readAccentParam(url)` — new
+- `bootAccent()` — new
+- The pre-FOUC `<script is:inline>` block — new
 
-Crucially, the existing `initAccent()` at [app.js:46](design/suryaavala-com/project/app.js) becomes a thin wrapper around `bootAccent()` — it no longer needs to read localStorage directly, because `bootAccent()` does. The dev Tweaks panel's swatch click handler at [app.js:714–719](design/suryaavala-com/project/app.js) imports `applyAccent` and `persistAccent` from `/src/lib/accent.ts` instead of mutating localStorage directly. The dev panel becomes a *consumer* of the same API the user picker uses.
+Crucially, the existing `initAccent()` at [app.js:46](design/suryaavala-com/project/app.js) becomes a thin wrapper around `bootAccent()` — it no longer needs to read localStorage directly, because `bootAccent()` does. The dev Tweaks panel's swatch click handler at [app.js:714–719](design/suryaavala-com/project/app.js) imports `applyAccent` and `persistAccent` from `/src/lib/accent.ts` instead of mutating localStorage directly. The dev panel becomes a _consumer_ of the same API the user picker uses.
 
 ---
 
@@ -423,12 +434,12 @@ The light-mode token sheet ([02_design.md §3.1 lines 113–138](02_design.md)) 
 **Mitigation:** the `--brand-body` token is the brightened/darkened variant explicitly intended for "body-size purple text" ([01_design.md §3.1 WCAG note](01_design.md)). Every component that renders accent at body size already reads `--brand-body`, not `--brand`. We must **expand the same `--brand-body` discipline to the other four accents** and ship light-mode variants for each:
 
 | Key      | `--brand` (dark) | `--brand-body` (dark) | `--brand` (light) | `--brand-body` (light) |
-|----------|------------------|------------------------|-------------------|-------------------------|
-| `purple` | `#bd93f9`        | `#c4a0ff`              | `#5b21b6`         | `#5b21b6`               |
-| `cyan`   | `#8be9fd`        | `#b4f0ff`              | `#075e7a`         | `#075e7a`               |
-| `green`  | `#50fa7b`        | `#7effa0`              | `#0f6b34`         | `#0f6b34`               |
-| `orange` | `#ffb86c`        | `#ffce99`              | `#9a3412`         | `#9a3412`               |
-| `pink`   | `#ff79c6`        | `#ffa2d6`              | `#9d174d`         | `#9d174d`               |
+| -------- | ---------------- | --------------------- | ----------------- | ---------------------- |
+| `purple` | `#bd93f9`        | `#c4a0ff`             | `#5b21b6`         | `#5b21b6`              |
+| `cyan`   | `#8be9fd`        | `#b4f0ff`             | `#075e7a`         | `#075e7a`              |
+| `green`  | `#50fa7b`        | `#7effa0`             | `#0f6b34`         | `#0f6b34`              |
+| `orange` | `#ffb86c`        | `#ffce99`             | `#9a3412`         | `#9a3412`              |
+| `pink`   | `#ff79c6`        | `#ffa2d6`             | `#9d174d`         | `#9d174d`              |
 
 The light-mode hexes on the right come directly from the v2 light-mode token sheet ([02_design.md §3.1 lines 127–134](02_design.md)) — those are already shipped, AA-tuned, deeper variants. `applyAccent()` checks `documentElement.classList.contains('light')` and applies the appropriate column. CI runs an automated contrast audit (`axe-core` via `@playwright/test`) against all 10 combinations (5 accents × 2 themes) before every release.
 
@@ -453,16 +464,20 @@ The "Keep this accent?" toast uses a 200ms slide-in. It must be wrapped in:
 
 ```css
 @media (prefers-reduced-motion: reduce) {
-  .accent-toast { animation: none; opacity: 1; transform: none; }
+  .accent-toast {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 ```
 
 ### 7.4 Screen-reader semantics
 
-* The picker is a `<fieldset>` with a `<legend>Accent</legend>`. SR users hear "Accent, group, 5 buttons."
-* Each swatch is `<button aria-label="Set accent to cyan" aria-pressed="true|false">`. The current selection is announced.
-* The `?` keyboard shortcut is documented in a visually-hidden `<p class="sr-only">` paragraph adjacent to the picker.
-* The toast is `role="status" aria-live="polite"`, *not* `role="alert"` — it's an offer, not an emergency.
+- The picker is a `<fieldset>` with a `<legend>Accent</legend>`. SR users hear "Accent, group, 5 buttons."
+- Each swatch is `<button aria-label="Set accent to cyan" aria-pressed="true|false">`. The current selection is announced.
+- The `?` keyboard shortcut is documented in a visually-hidden `<p class="sr-only">` paragraph adjacent to the picker.
+- The toast is `role="status" aria-live="polite"`, _not_ `role="alert"` — it's an offer, not an emergency.
 
 ---
 
@@ -474,31 +489,31 @@ The whole point of shipping the picker is to learn whether it matters. Without a
 
 Three events. All fired client-side via the existing analytics shim (assumed: a thin wrapper over the chosen analytics provider; if no analytics provider is configured at production deploy, these become no-ops via feature flag).
 
-| Event name | When fired | Properties |
-|---|---|---|
-| `accent_changed` | Any accent change (picker or dev panel) | `{ accent: AccentKey, source: 'picker' \| 'param' \| 'dev_panel', previous: AccentKey \| null }` |
-| `accent_param_seen` | First paint where `?accent=<k>` was in the URL (whether or not the value was valid) | `{ raw: string, valid: boolean, accent: AccentKey \| null, referrer_host: string }` |
-| `accent_keep_decision` | User clicks `Keep` or `Dismiss` on the toast (or auto-dismiss fires) | `{ accent: AccentKey, decision: 'keep' \| 'dismiss' \| 'auto_dismiss', dwell_ms: number }` |
+| Event name             | When fired                                                                          | Properties                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `accent_changed`       | Any accent change (picker or dev panel)                                             | `{ accent: AccentKey, source: 'picker' \| 'param' \| 'dev_panel', previous: AccentKey \| null }` |
+| `accent_param_seen`    | First paint where `?accent=<k>` was in the URL (whether or not the value was valid) | `{ raw: string, valid: boolean, accent: AccentKey \| null, referrer_host: string }`              |
+| `accent_keep_decision` | User clicks `Keep` or `Dismiss` on the toast (or auto-dismiss fires)                | `{ accent: AccentKey, decision: 'keep' \| 'dismiss' \| 'auto_dismiss', dwell_ms: number }`       |
 
 ### 8.2 Dimensions on every page-view
 
-A single dimension `accent` (one of the five keys) is attached to every page-view event. This lets us slice existing metrics (bounce rate, scroll depth, `/ping` modal opens, time-on-page) by the user's chosen accent. **Critical**: this dimension reflects the *active* accent at the moment of the page-view, not any historical preference. This avoids retroactive contamination of the existing dataset.
+A single dimension `accent` (one of the five keys) is attached to every page-view event. This lets us slice existing metrics (bounce rate, scroll depth, `/ping` modal opens, time-on-page) by the user's chosen accent. **Critical**: this dimension reflects the _active_ accent at the moment of the page-view, not any historical preference. This avoids retroactive contamination of the existing dataset.
 
 ### 8.3 What we will look at after 4 weeks
 
-| Question | Metric |
-|---|---|
-| Does anyone use it? | `% sessions with ≥1 accent_changed event` |
-| Which accents are picked? | Distribution of `accent_changed.accent` for `source = 'picker'` |
-| Does the share-link mechanic work? | `count(accent_param_seen.valid=true) / count(sessions)` |
-| Does the toast convert? | `count(accent_keep_decision.decision='keep') / count(accent_param_seen.valid=true)` |
-| Does choice correlate with behaviour? | `bounce_rate by dimension(accent)`; `/ping` modal-open rate by `dimension(accent)` |
+| Question                              | Metric                                                                              |
+| ------------------------------------- | ----------------------------------------------------------------------------------- |
+| Does anyone use it?                   | `% sessions with ≥1 accent_changed event`                                           |
+| Which accents are picked?             | Distribution of `accent_changed.accent` for `source = 'picker'`                     |
+| Does the share-link mechanic work?    | `count(accent_param_seen.valid=true) / count(sessions)`                             |
+| Does the toast convert?               | `count(accent_keep_decision.decision='keep') / count(accent_param_seen.valid=true)` |
+| Does choice correlate with behaviour? | `bounce_rate by dimension(accent)`; `/ping` modal-open rate by `dimension(accent)`  |
 
 ### 8.4 Privacy
 
-* No PII stored. Accent key is a single enum, not even a free-form value (the `accent_param_seen.raw` field is the only place a raw user input appears, and it's truncated to 32 chars).
-* No fingerprinting use of accent — explicitly **not** combined with viewport, UA, or theme to construct a synthetic ID. A note in the analytics SOP enforces this.
-* No cross-site / cross-domain transmission of the accent key.
+- No PII stored. Accent key is a single enum, not even a free-form value (the `accent_param_seen.raw` field is the only place a raw user input appears, and it's truncated to 32 chars).
+- No fingerprinting use of accent — explicitly **not** combined with viewport, UA, or theme to construct a synthetic ID. A note in the analytics SOP enforces this.
+- No cross-site / cross-domain transmission of the accent key.
 
 ---
 
@@ -508,55 +523,55 @@ A single dimension `accent` (one of the five keys) is attached to every page-vie
 
 Both surfaces:
 
-* Read from and write to the same `localStorage["sa-accent"]` key.
-* Call the same `applyAccent()` function from `/src/lib/accent.ts`.
-* Use the same five-preset `ACCENT_MAP`.
+- Read from and write to the same `localStorage["sa-accent"]` key.
+- Call the same `applyAccent()` function from `/src/lib/accent.ts`.
+- Use the same five-preset `ACCENT_MAP`.
 
 This means a developer running the Claude Design preview can change the accent in either place and observe the same end state. The dev panel remains gated by `parent.postMessage({type: "__activate_edit_mode"})`; production users never see it. The user picker is always visible in the footer in production. There is no scenario where both surfaces disagree about the active accent because there is one source of truth.
 
 ### 9.2 Phased rollout
 
-| Phase | What ships | Gating | Verification |
-|---|---|---|---|
-| **0 — Refactor** | Extract `ACCENT_MAP`, `applyAccent`, `persistAccent` into `/src/lib/accent.ts`. Dev panel imports from the new module. **Behavioural no-op.** | None | Existing Tweaks panel still works in preview. Storybook snapshot of all 5 dev-panel swatches unchanged. |
-| **1 — Pre-FOUC hook + boot logic** | Inline head script. `bootAccent()` runs on every page. **No new UI surface yet.** | None | Manual: `?accent=cyan` URL paints cyan immediately, strips param, no toast (toast not shipped yet). |
-| **2 — Footer picker** | `<AccentPicker>` Svelte island mounted in `<Layout>` footer. | None | Playwright e2e: pick each of 5 accents, verify CSS variables update, verify localStorage write, verify nav active-link colour reflects the change. |
-| **3 — Toast + keyboard accelerator** | `<AccentToast>` mounted at root; `?` keypress handler. | None | E2e: arrive at `?accent=cyan`, see toast, click Keep, verify localStorage. Same flow with Dismiss + auto-dismiss. |
-| **4 — Analytics** | Three events wired through analytics shim. `accent` dimension on page-views. | Behind a `ANALYTICS_ENABLED` env flag, defaulting on in production. | Verify events appear in analytics provider dashboard within 1h of canary deploy. |
+| Phase                                | What ships                                                                                                                                    | Gating                                                              | Verification                                                                                                                                       |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **0 — Refactor**                     | Extract `ACCENT_MAP`, `applyAccent`, `persistAccent` into `/src/lib/accent.ts`. Dev panel imports from the new module. **Behavioural no-op.** | None                                                                | Existing Tweaks panel still works in preview. Storybook snapshot of all 5 dev-panel swatches unchanged.                                            |
+| **1 — Pre-FOUC hook + boot logic**   | Inline head script. `bootAccent()` runs on every page. **No new UI surface yet.**                                                             | None                                                                | Manual: `?accent=cyan` URL paints cyan immediately, strips param, no toast (toast not shipped yet).                                                |
+| **2 — Footer picker**                | `<AccentPicker>` Svelte island mounted in `<Layout>` footer.                                                                                  | None                                                                | Playwright e2e: pick each of 5 accents, verify CSS variables update, verify localStorage write, verify nav active-link colour reflects the change. |
+| **3 — Toast + keyboard accelerator** | `<AccentToast>` mounted at root; `?` keypress handler.                                                                                        | None                                                                | E2e: arrive at `?accent=cyan`, see toast, click Keep, verify localStorage. Same flow with Dismiss + auto-dismiss.                                  |
+| **4 — Analytics**                    | Three events wired through analytics shim. `accent` dimension on page-views.                                                                  | Behind a `ANALYTICS_ENABLED` env flag, defaulting on in production. | Verify events appear in analytics provider dashboard within 1h of canary deploy.                                                                   |
 
 Each phase is independently revertible. If phase 3 misbehaves (toast covers a layout element, focus mis-restored, etc.) we revert just phase 3 without touching phases 0–2.
 
 ### 9.3 Backwards compatibility with shared links
 
-There were no `?accent=*` links in production prior to this RFC. Phase 1 is the moment the param becomes meaningful. The team should announce the new param shape in `/notes` (a short post: *"You can now share suryaavala.com with a personal accent"*) only **after** Phase 4 lands, so analytics captures the attribution.
+There were no `?accent=*` links in production prior to this RFC. Phase 1 is the moment the param becomes meaningful. The team should announce the new param shape in `/notes` (a short post: _"You can now share suryaavala.com with a personal accent"_) only **after** Phase 4 lands, so analytics captures the attribution.
 
 ### 9.4 Rollback plan
 
 If the picker creates more support burden than value (unlikely; flagged here for completeness):
 
-* Remove `<AccentPicker>` from `<Layout>` (1-line revert).
-* Remove the inline pre-FOUC script (1-line revert).
-* `localStorage["sa-accent"]` values written by users persist harmlessly — the dev panel can still read them, and they have no effect because the production site reverts to the hard-coded `--brand: #bd93f9`.
-* No data migration required.
+- Remove `<AccentPicker>` from `<Layout>` (1-line revert).
+- Remove the inline pre-FOUC script (1-line revert).
+- `localStorage["sa-accent"]` values written by users persist harmlessly — the dev panel can still read them, and they have no effect because the production site reverts to the hard-coded `--brand: #bd93f9`.
+- No data migration required.
 
 ---
 
 ## 10. Open Questions / Risks
 
-* **[OPEN]** Picker placement on `/notes` long-form pages: the footer there is far below the fold for any long article. Should the picker be sticky on `/notes` only? Out of scope for this RFC; note for v2.2.
-* **[OPEN]** Mobile footer-picker affordance: the `?` keyboard accelerator does not exist on mobile. Should there be a small "Theme" entry in a hamburger menu we don't yet have? Currently the site has no hamburger nav; adding one is bigger than this RFC. Defer.
-* **[OPEN]** Per-accent OG (option 5.1.ii) revisit: if `accent_param_seen` exceeds 5% of sessions over 4 weeks, escalate to a follow-on RFC for static per-accent OGs.
-* **[OPEN]** Light-mode contrast audit gap: the four non-purple accents have light-mode hexes proposed in §7.1, but those hexes have not been independently verified against every consumer of `--brand` in light mode (e.g., the Hero gradient-clipped text where contrast is harder to compute analytically). Phase 2 acceptance includes a manual axe-core sweep across all 10 (accent × theme) combinations, with any failure blocking the phase.
-* **[RISK — low]** Cache poisoning via `?accent=`: a malicious link could embed `?accent=<key>` to manipulate a user's first impression. Mitigated because (i) only five values are accepted, (ii) the value is silently ignored if invalid, (iii) the toast asks before persisting, (iv) the worst-case impact is a different brand colour for one session.
-* **[RISK — low]** Analytics dimension cardinality: adding an `accent` dimension to every page-view multiplies session-level reports by 5. Most analytics providers handle this trivially; flagged for completeness if our provider has cardinality limits.
-* **[RISK — medium]** `ACCENT_MAP` drift between the inline pre-FOUC script (§6.3) and `/src/lib/accent.ts` (§6.2). **Mitigation:** dedicated CI test (`scripts/check-accent-parity.ts`) parses both and fails the build on mismatch. Required gate for Phase 1.
+- **[OPEN]** Picker placement on `/notes` long-form pages: the footer there is far below the fold for any long article. Should the picker be sticky on `/notes` only? Out of scope for this RFC; note for v2.2.
+- **[OPEN]** Mobile footer-picker affordance: the `?` keyboard accelerator does not exist on mobile. Should there be a small "Theme" entry in a hamburger menu we don't yet have? Currently the site has no hamburger nav; adding one is bigger than this RFC. Defer.
+- **[OPEN]** Per-accent OG (option 5.1.ii) revisit: if `accent_param_seen` exceeds 5% of sessions over 4 weeks, escalate to a follow-on RFC for static per-accent OGs.
+- **[OPEN]** Light-mode contrast audit gap: the four non-purple accents have light-mode hexes proposed in §7.1, but those hexes have not been independently verified against every consumer of `--brand` in light mode (e.g., the Hero gradient-clipped text where contrast is harder to compute analytically). Phase 2 acceptance includes a manual axe-core sweep across all 10 (accent × theme) combinations, with any failure blocking the phase.
+- **[RISK — low]** Cache poisoning via `?accent=`: a malicious link could embed `?accent=<key>` to manipulate a user's first impression. Mitigated because (i) only five values are accepted, (ii) the value is silently ignored if invalid, (iii) the toast asks before persisting, (iv) the worst-case impact is a different brand colour for one session.
+- **[RISK — low]** Analytics dimension cardinality: adding an `accent` dimension to every page-view multiplies session-level reports by 5. Most analytics providers handle this trivially; flagged for completeness if our provider has cardinality limits.
+- **[RISK — medium]** `ACCENT_MAP` drift between the inline pre-FOUC script (§6.3) and `/src/lib/accent.ts` (§6.2). **Mitigation:** dedicated CI test (`scripts/check-accent-parity.ts`) parses both and fails the build on mismatch. Required gate for Phase 1.
 
 ---
 
 ## 11. Decision Summary
 
-| Sub-question | Recommendation |
-|---|---|
-| **(a)** Discoverability surface | **Footer-mounted picker** with a `?` keyboard accelerator. Reuses existing `.swatches` styles ([styles.css:455–464](design/suryaavala-com/project/styles.css)). No nav changes. |
+| Sub-question                               | Recommendation                                                                                                                                                                                              |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **(a)** Discoverability surface            | **Footer-mounted picker** with a `?` keyboard accelerator. Reuses existing `.swatches` styles ([styles.css:455–464](design/suryaavala-com/project/styles.css)). No nav changes.                             |
 | **(b)** URL query-param shape & precedence | **`?accent=<key>`** with the **hybrid precedence rule**: param applies for the session, strip from URL, do not auto-persist; show a "Keep this accent?" toast that converts to persistence on user consent. |
-| **(c)** OG image strategy | **One canonical purple OG** for v2.1. Brand cohesion + zero runtime cost + reversible. Revisit per-accent OGs only if `accent_param_seen` exceeds 5% of sessions in the 4-week post-launch window. |
+| **(c)** OG image strategy                  | **One canonical purple OG** for v2.1. Brand cohesion + zero runtime cost + reversible. Revisit per-accent OGs only if `accent_param_seen` exceeds 5% of sessions in the 4-week post-launch window.          |

--- a/specs/rfc_end_user_accent_picker.md
+++ b/specs/rfc_end_user_accent_picker.md
@@ -1,0 +1,562 @@
+
+# RFC: End-User Accent Picker for `suryaavala.com`
+
+**Document Owner:** Staff Software Engineer / TPM
+
+**Project:** `suryaavala.com` v2.1 — End-User Accent Personalisation
+
+**Status:** DRAFT
+
+**Source:** Resolves `[OPEN]` item in [02_design.md §7 line 573](02_design.md). Builds on the dev-only Tweaks panel defined in [02_design.md §3.5 lines 213–231](02_design.md) without modifying it.
+
+**Date:** 2026-04-26
+
+**Reviewers:** @VP_AIPlatform, @PrincipalArchitect, @StaffFullStack, @DistinguishedMentor
+
+---
+
+## 1. Context & Motivation
+
+### 1.1 What exists today
+
+The site ships with a **dev-only Tweaks panel** ([02_design.md §3.5](02_design.md), [app.js:700–732](design/suryaavala-com/project/app.js)) bottom-right, fixed-positioned, 260px wide. It exposes two controls:
+
+| Control | Storage Key | Values |
+|---|---|---|
+| Homepage variant | `localStorage["sa-home-variant"]` | `safe` \| `bold` |
+| Brand accent | `localStorage["sa-accent"]` | `purple` \| `cyan` \| `green` \| `orange` \| `pink` |
+
+The accent control mutates `--brand` and `--brand-body` via `applyAccent()` ([app.js:41–46](design/suryaavala-com/project/app.js)):
+
+```javascript
+function applyAccent(k) {
+  const a = ACCENT_MAP[k] || ACCENT_MAP.purple;
+  document.documentElement.style.setProperty("--brand", a.brand);
+  document.documentElement.style.setProperty("--brand-body", a.body);
+}
+```
+
+Because every component that renders in the brand colour reads `var(--brand)` (Hero gradient, nav active-link underline, focus rings, project-card hover glow, radar polygon stroke, contact CTA, etc.), a single `documentElement.style.setProperty` recolours the entire site without any DOM rewrite.
+
+The five preset `(brand, brand-body)` pairs (canonical reference, copied verbatim from [app.js:34–40](design/suryaavala-com/project/app.js)):
+
+| Key      | `--brand`  | `--brand-body` |
+|----------|------------|----------------|
+| `purple` | `#bd93f9`  | `#c4a0ff`      |
+| `cyan`   | `#8be9fd`  | `#b4f0ff`      |
+| `green`  | `#50fa7b`  | `#7effa0`      |
+| `orange` | `#ffb86c`  | `#ffce99`      |
+| `pink`   | `#ff79c6`  | `#ffa2d6`      |
+
+The panel itself is **gated** by a `parent.postMessage({type: "__activate_edit_mode"})` event from the Claude Design preview iframe ([app.js:721–727](design/suryaavala-com/project/app.js)). Because GH Pages → Cloudflare never sends that message, production users cannot reach it. The panel and its swatches are inert in the production DOM (CSS sets `.tweaks { display: none; }` until `.open` is added — [styles.css:409, 413](design/suryaavala-com/project/styles.css)).
+
+### 1.2 Why a user-facing accent picker might matter
+
+Three weak forces pull in this direction; one strong force pushes back.
+
+**Pulls:**
+
+1. **Audience-routing alignment.** [01_design.md §3.3](01_design.md) names three intended cohorts (recruiters / engineers / researchers). A picker plus query-param links lets the site nudge its own colour for a given share context — e.g. a LinkedIn post for executive recruiters carries `?accent=purple` (the brand default), an HN thread aimed at infra engineers carries `?accent=cyan` (`--infra` token). This is closer to "deliberate share-context theming" than personalisation.
+2. **Personal expression / dwell time.** A small fraction of returning visitors enjoy theming controls (cf. GitHub theme picker, Linear's icon themes). Optionality is cheap in dwell-seconds even when used by <2% of sessions.
+3. **Brand cohesion across share links.** When the site is screenshot-shared (Twitter card, LinkedIn preview, Slack unfurl), the OG image is the visual anchor. If a user sets `cyan` and then shares the URL, their preview should ideally match what they shared from. Otherwise the OG and the destination disagree, undermining the "I curated this" affordance the picker creates in the first place.
+
+**Pushes back:**
+
+1. **Design integrity.** The whole point of curated accents is that the canonical `purple` carries identity. Letting users freely pick risks fragmenting "what the site looks like" in screenshots and discussions. We *deliberately* ship five presets — not a colour wheel — to hold the line on cohesion.
+2. **Analytics noise.** Per-session accent state pollutes session recordings and heat-map composites. Mitigated by tracking the dimension explicitly (see §9), not by avoiding it.
+3. **OG image complexity.** The default GH Pages/Cloudflare deployment pipeline ships a *static* OG asset. Per-accent OGs cost build time, edge compute, or both. See §6.
+
+The remit of this RFC is to land **(a)** a discoverability surface, **(b)** a query-param fallback, and **(c)** an OG-image policy — opinionated recommendations, not just option enumeration.
+
+---
+
+## 2. Goals / Non-Goals
+
+### 2.1 Goals
+
+* **G1.** Ship a production-visible UI surface that lets users pick any of the **five existing presets** and persist their choice across navigations and reloads.
+* **G2.** Ship a `?accent=<key>` URL query-param that produces the same end state as a manual pick — usable for direct linking, share buttons, and QR codes.
+* **G3.** Resolve the OG-image question with one decision and one rollback path.
+* **G4.** Coexist with the dev-only Tweaks panel from [02_design.md §3.5](02_design.md). Both surfaces write to the same `localStorage["sa-accent"]` key; the dev panel remains dev-only.
+* **G5.** Preserve all accessibility properties of the v2 design — WCAG AA contrast on every preset, focus-visible behaviour on the new control, `prefers-reduced-motion` handling on the swap transition.
+* **G6.** Add zero new external dependencies. Implementation is hand-authored Astro + Svelte using existing tokens.
+
+### 2.2 Non-Goals
+
+* **NG1.** No full theme builder. No colour-wheel input, no hex entry, no per-channel HSL sliders.
+* **NG2.** No new accent presets. Five only. If a sixth preset is ever needed, it gets its own RFC and a contrast audit ([01_design.md §3.1](01_design.md) WCAG note).
+* **NG3.** No per-page accent overrides. The accent is **site-wide and per-user**, not per-page or per-route. A user who picked `cyan` sees `cyan` everywhere — including `/runtime`, `/stack`, `/notes`, etc.
+* **NG4.** No theme builder for the **homepage variant** (`safe`/`bold`). That stays gated to the dev panel for v2.1. The variant decision is editorial; the accent decision is cosmetic.
+* **NG5.** No change to the dev Tweaks panel UX, layout, or activation protocol. This RFC adds a *parallel* user surface, not a replacement.
+* **NG6.** No server-side personalisation, no auth, no per-user persistence beyond `localStorage`. A user clearing site data loses their preference, by design.
+* **NG7.** No cookie banner. `localStorage["sa-accent"]` is a strictly-necessary functional preference (UI personalisation, no PII, no tracking) — same legal posture as the existing `sa-theme` and `sa-home-variant` keys.
+
+---
+
+## 3. Design Options for (a) — Discoverability Surface
+
+We need *one* place users can find the picker. Five candidates were considered:
+
+| # | Option | Discoverability | Visual noise | Implementation cost | Mobile fit | Notes |
+|---|---|---|---|---|---|---|
+| 3.1 | **Nav-mounted swatch row** (5 dots inline next to theme toggle) | High | Medium-high | Low | Poor — eats sticky-nav width budget | Sticky nav is already dense (mono brand mark, slash-prefixed links, theme toggle, Open-to-Work CTA — [02_design.md §3.2 Glass Nav](02_design.md)). Adding 5 swatches at ≤1024px collides with the CTA, which already drops out below 1024px. |
+| 3.2 | **Footer-mounted picker** (5 swatches in a `.footer` row) | Low–medium | Low | Low | Good | Below the fold for first-paint. Discoverable for engaged scrollers; invisible to bouncers. Cheap. |
+| 3.3 | **Dedicated `/preferences` route** | Very low | Zero on every other page | Medium (one new route, page chrome, nav entry) | Good | Bloats site map (currently 6 routes — [02_design.md §3.3](02_design.md)). Discoverability requires a nav entry, looping back to 3.1's problem. Overkill for one toggle and five swatches. |
+| 3.4 | **Hidden-until-keypress** (`?` opens a tray) | Very low for non-keyboard users | Zero | Low | Bad — no on-screen affordance on touch | Cute easter egg. Unsuitable as the *primary* surface; could supplement another. |
+| 3.5 | **Footer command palette** (`Cmd-K` style, channels + accents + theme) | Low–medium | Zero on first paint | High | Awkward (requires pinned trigger) | Over-engineered for one decision. Worth reconsidering when the surface count exceeds three. |
+
+### 3.6 Recommendation: **Footer-mounted picker (3.2), with a keyboard-shortcut accelerator (3.4) layered on top**
+
+Rationale:
+
+* **Honesty about who uses it.** Users who care about theming will scroll for it; users who don't shouldn't carry the cognitive cost in the nav. The footer is the conventional home for preferences (cf. dev.to, Stripe Docs, Tailwind).
+* **Nav stays clean.** The Glass Nav row is already operating at its visual budget — five 24px swatches in there would force the Open-to-Work CTA off the layout earlier than 1024px, hurting the conversion signal.
+* **Power-user accelerator costs ~10 LOC.** Pressing `?` (or `Shift-/`) scrolls smoothly to the footer picker and focuses the first swatch. This makes the feature feel "discovered" without making it loud. It is an accessibility win for keyboard users and a personality win for the developer-native audience.
+* **Mobile parity.** The footer is reachable on mobile by definition (it's where you end up). The nav option has no graceful fallback on `≤640px` — mobile users would get no picker at all.
+
+### 3.7 Visual & layout sketch (footer picker)
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  © 2026 Surya Avala     ·     /architecture · /runtime · /stack · ...    │
+│                                                                          │
+│  Accent  ●  ●  ●  ●  ●     Theme  [☀ / ☾]                                │
+│         purple cyan green orange pink                                    │
+│                                                                          │
+│  press ?  to jump here                                                   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+* Five 24×24px swatches identical in dimension/markup to the existing dev-panel `.swatches button` ([styles.css:455–464](design/suryaavala-com/project/styles.css)) — reuses the CSS, no new tokens.
+* The active swatch wears the same `.on` class (border `var(--text)` at 2px) used by the dev panel ([styles.css:464](design/suryaavala-com/project/styles.css)). This keeps the visual contract consistent across both surfaces.
+* `aria-label` per swatch: `"Set accent to {name}"`. The active swatch additionally carries `aria-pressed="true"`.
+* The "press `?` to jump here" hint is shown only on viewports ≥1024px and only on first session (gated by a `localStorage["sa-accent-hint-dismissed"]` flag flipped after first interaction or 5s view).
+
+### 3.8 What the footer picker does NOT do
+
+* It does **not** let users change the homepage variant. That stays dev-only.
+* It does **not** let users enter a custom hex.
+* It does **not** announce itself with a banner, toast, or first-visit modal. Discovery is via scroll, share-link param, or `?` keypress.
+
+---
+
+## 4. Design Options for (b) — URL Query Param
+
+### 4.1 Param shape
+
+Three candidate shapes:
+
+| Shape | Pros | Cons |
+|---|---|---|
+| `?accent=cyan` | Self-describing, matches preset key namespace from [app.js:34–40](design/suryaavala-com/project/app.js), grep-friendly in analytics | Only handles accent; we may want similar mechanics for theme later |
+| `?theme=cyan` | Reuses the `theme` mental model | Conflates light/dark theme with accent — the site already has a `sa-theme` storage key that means light vs dark. Collision risk. |
+| `?ui=cyan-dark` | Compact, multi-axis-ready | Opaque, hard to share verbally, requires a parser |
+
+**Recommendation: `?accent=<key>`.** Direct mapping to `ACCENT_MAP` keys, no parsing, no collision with the existing `sa-theme` semantic. If later we need a light/dark override via URL, it gets a separate `?theme=light|dark` param.
+
+### 4.2 Validation
+
+* Allowed values: exactly the five keys in `ACCENT_MAP` — `purple` | `cyan` | `green` | `orange` | `pink`.
+* Unknown values are **silently ignored** (not redirected, not error-toasted). Defence against share-link bit-rot and link-shortener mutilation.
+* Case-insensitive on read (`?accent=CYAN` works); we lowercase before lookup.
+
+### 4.3 Precedence
+
+The interesting question: what wins between the URL param, `localStorage`, and the per-document default?
+
+Three candidate precedence rules:
+
+| Rule | Behaviour | Pros | Cons |
+|---|---|---|---|
+| **(A) URL > localStorage > default**, consume-and-store | First load with `?accent=cyan` writes `cyan` to localStorage and strips the param from the URL via `history.replaceState`. Subsequent navigations see `cyan` in storage. | Maximum continuity — share link instantly becomes "your" theme. Clean URL after first paint. | Surprise: a user who *had* `pink` set, then clicked a `?accent=cyan` link, has now silently lost their preference. |
+| **(B) URL > localStorage > default**, ephemeral (read every load, never stored) | The param wins for that single page-view; on next navigation without the param, localStorage (or default) takes over. | No silent override of saved preferences. Predictable. | Sharing a link doesn't give the recipient a *persistent* accent. They have to use the picker themselves to keep it. |
+| **(C) localStorage > URL > default** | If the user has *ever* picked an accent, that wins forever. Param only seeds the *first* visit. | Preserves "I made a choice." Shared links work for fresh visitors. | Returning visitors with a stale localStorage value get a worse share-link experience than expected. |
+
+### 4.4 Recommendation: Hybrid of (A) and (B) — **URL wins for the session; we offer to persist**
+
+The mechanic:
+
+1. On first paint, read `?accent=<k>` from the URL.
+2. If `<k>` is valid:
+   * Apply it immediately via `applyAccent(k)` ([app.js:41–46](design/suryaavala-com/project/app.js)).
+   * Strip the param from the URL via `history.replaceState` (clean address bar, clean copy-paste, OG re-share continues to work because the param is consumed *after* the OG fetch).
+   * **Do not write it to localStorage.** The session state diverges from the persisted state — exactly as in option (B).
+3. Render a small, dismissible footer toast: `"Trying out cyan. Keep this accent?  [Keep]  [Dismiss]"`.
+   * `Keep` → write `localStorage["sa-accent"] = k`, remove the toast.
+   * `Dismiss` → revert to the localStorage value (or default `purple`) on next navigation, remove the toast.
+   * Auto-dismiss after 12s (no implicit save — silence means revert).
+4. If `?accent=<k>` is invalid or absent, behave normally: read `localStorage["sa-accent"]` or fall back to `purple`.
+
+This is option (B) with a one-tap upgrade to (A). It is the only rule that:
+
+* Lets share-links instantly recolour the destination (G2).
+* Never silently overwrites a user's saved choice (Goal G6 spirit).
+* Keeps the URL clean for re-share / SEO.
+* Gives the recipient explicit consent before persistence.
+
+The toast is a Svelte island, accent-tinted to the param-supplied colour (so the recipient sees the proposed colour on the toast itself). It uses the same focus-trap and keyboard-dismiss (`Esc`) primitives as the Contact Modal ([02_design.md §3.2 Contact Modal row](02_design.md), [app.js:734–817](design/suryaavala-com/project/app.js)) — minus the focus trap (toast is non-modal).
+
+### 4.5 What about no-JS users?
+
+The query param is processed in JS. No-JS users get the default purple regardless of `?accent=cyan`. This is acceptable: the entire `applyAccent` pipeline is JS-only ([app.js:41–46](design/suryaavala-com/project/app.js)) and the no-JS audience is already accepting the v2 site without animations, count-ups, or the typing hero. Adding an SSR-time accent override would require route-level pre-rendering of every accent variant — disproportionate for the audience size.
+
+---
+
+## 5. Decision for (c) — OG Image
+
+### 5.1 The setup
+
+The Open Graph image is a single static asset shipped from `/public/og.png` (1200×630, generated at build time per [01_design.md §5.2 Open Graph](01_design.md)). It carries the site logo, name, role line, and a brand-purple rim/glow.
+
+Three candidate strategies:
+
+| Option | Build-time cost | Runtime cost | SEO impact | Social-share fidelity | Operational complexity |
+|---|---|---|---|---|---|
+| **(i) One canonical purple OG** | 0 | 0 | None (canonical OG cached by Facebook, LinkedIn, Twitter, Slack) | Low: share `?accent=cyan`, recipient sees purple OG, then a cyan site | None |
+| **(ii) Five static OGs, picked via param** | 5× build time for OG generation, 5× asset weight in `/public` | None (URL maps to file) | Slight: each accent has its own canonical OG URL — Twitter/Slack will cache them independently | High: share matches site colour | Medium: build script must produce 5 OGs and `<meta og:image>` must be set per param at SSR time |
+| **(iii) Edge-generated OG via Cloudflare Workers** | 0 (no static assets) | ~50–200ms cold, free tier covers <100k req/day | Higher: every request to `/og.png?accent=cyan` is a Worker invocation; URL-cache discipline is essential | High: instant per-accent OGs, plus future variant axes (theme, etc.) | High: introduces a Worker to a previously zero-runtime stack — violates [02_design.md §2.2](02_design.md) "no runtime fetch" principle |
+
+### 5.2 Recommendation: **(i) One canonical purple OG — for v2.1**
+
+Rationale, in order of weight:
+
+1. **Brand cohesion is the *whole point* of curating five presets.** `purple` is identity. The OG is the identity-bearing surface of every share. Letting a user repaint the OG at will is a category mistake — it converts the site's visual brand into per-user marketing collateral. The OG should always say "this is suryaavala.com," not "this is suryaavala.com as filtered by a stranger's preferences."
+2. **Cost vs benefit.** Option (ii) ships 5× the OG asset weight and complicates the SSR pipeline for an effect most users will never notice. Option (iii) introduces a Worker — runtime infrastructure — into a stack whose explicit non-goal in [02_design.md §2.2](02_design.md) is *no runtime fetch*. Both costs are real; the benefit is "the share image matches the site for users who set a custom accent."
+3. **The hybrid precedence rule (§4.4) absorbs the inconsistency cleanly.** When a recipient clicks a `?accent=cyan` link:
+   * The OG that pulled them in was purple (canonical brand).
+   * The site they land on is cyan (because the URL says so).
+   * The toast asks: "Keep this accent?" — converting the discrepancy into an *explanation* rather than a glitch.
+4. **SEO discipline.** A single canonical OG keeps Twitter card / LinkedIn / Slack unfurl caches consistent. Multi-OG strategies have a long history of cache-coherence bugs (Slack caches by URL, not by query-param; Twitter dedupes aggressively). Not worth it.
+5. **Reversibility.** If post-launch analytics show >5% of sessions arriving via `?accent=` URLs *and* the brand team requests per-accent OGs, we can ship option (ii) as a follow-on RFC. Option (iii) remains the long-tail option if/when we add an OG that is itself dynamic for other reasons (per-page, per-note, per-role).
+
+### 5.3 Out of scope for this RFC, flagged for the next one
+
+* Per-page OG variations (e.g. `/runtime` showing the timeline, `/stack` showing the radar chart). Currently every route uses the homepage OG. That is an editorial gap unrelated to accent. If addressed in a future RFC, edge-generation (option iii) becomes the obvious vehicle.
+
+---
+
+## 6. Implementation Sketch
+
+### 6.1 Files touched
+
+| File | Change type | Notes |
+|---|---|---|
+| `/src/components/AccentPicker.svelte` | **NEW** Svelte island | Footer picker UI |
+| `/src/components/AccentToast.svelte` | **NEW** Svelte island | "Keep this accent?" prompt |
+| `/src/lib/accent.ts` | **NEW** TS module | `ACCENT_MAP`, `applyAccent`, `readAccentParam`, `applyFromContext` |
+| `/src/layouts/Layout.astro` | EDIT | Mount `<AccentPicker>` in footer; mount `<AccentToast>` once at root |
+| `/src/styles/tokens.css` | UNCHANGED | No new tokens — reuses `--brand`, `--brand-body` |
+| `/src/data/accent.ts` (or co-located) | NEW const | Single source of truth for `ACCENT_MAP` — *replaces the duplicated map in [app.js:34–40](design/suryaavala-com/project/app.js)* once we port to Astro |
+| `tweaks/Tweaks.svelte` (existing dev panel) | EDIT (1 LOC) | Import `ACCENT_MAP` from `/src/lib/accent.ts` instead of duplicating it |
+
+The dev Tweaks panel and the user picker share the **same** `ACCENT_MAP` constant, the **same** `applyAccent()` function, and the **same** `localStorage["sa-accent"]` key. A change to any preset's hex automatically propagates to both surfaces. This is the load-bearing migration commitment of this RFC.
+
+### 6.2 The accent module
+
+```typescript
+// /src/lib/accent.ts
+export type AccentKey = 'purple' | 'cyan' | 'green' | 'orange' | 'pink';
+
+export const ACCENT_MAP: Record<AccentKey, { brand: string; body: string }> = {
+  purple: { brand: '#bd93f9', body: '#c4a0ff' },
+  cyan:   { brand: '#8be9fd', body: '#b4f0ff' },
+  green:  { brand: '#50fa7b', body: '#7effa0' },
+  orange: { brand: '#ffb86c', body: '#ffce99' },
+  pink:   { brand: '#ff79c6', body: '#ffa2d6' },
+};
+
+export const ACCENT_KEYS = Object.keys(ACCENT_MAP) as AccentKey[];
+const STORAGE_KEY = 'sa-accent';
+const DEFAULT_ACCENT: AccentKey = 'purple';
+
+export function isAccentKey(s: unknown): s is AccentKey {
+  return typeof s === 'string' && (ACCENT_KEYS as string[]).includes(s.toLowerCase());
+}
+
+export function applyAccent(k: AccentKey): void {
+  const a = ACCENT_MAP[k];
+  document.documentElement.style.setProperty('--brand',      a.brand);
+  document.documentElement.style.setProperty('--brand-body', a.body);
+}
+
+export function readAccentParam(url: URL): AccentKey | null {
+  const raw = url.searchParams.get('accent');
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  return isAccentKey(lower) ? (lower as AccentKey) : null;
+}
+
+export function readStoredAccent(): AccentKey {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return isAccentKey(v) ? (v as AccentKey) : DEFAULT_ACCENT;
+  } catch {
+    return DEFAULT_ACCENT;            // SSR / private mode / disabled storage
+  }
+}
+
+export function persistAccent(k: AccentKey): void {
+  try { localStorage.setItem(STORAGE_KEY, k); } catch { /* swallow */ }
+}
+
+/**
+ * Boot-time entrypoint. Returns whether a query-param override is active
+ * (so the layout can decide whether to mount the "Keep this accent?" toast).
+ */
+export function bootAccent(): { active: AccentKey; fromParam: boolean } {
+  const url = new URL(window.location.href);
+  const fromParam = readAccentParam(url);
+
+  if (fromParam) {
+    applyAccent(fromParam);
+    // Strip the param from the URL — non-destructive for SSR cache, OG, and copy-paste UX.
+    url.searchParams.delete('accent');
+    history.replaceState({}, '', url.toString());
+    return { active: fromParam, fromParam: true };
+  }
+
+  const stored = readStoredAccent();
+  applyAccent(stored);
+  return { active: stored, fromParam: false };
+}
+```
+
+### 6.3 Inline pre-FOUC hook (in `<head>`)
+
+To prevent a flash of purple before the swap runs (FOUC), `bootAccent()` is called from an inline blocking script in `<head>`, identical in spirit to the existing pre-FOUC theme script lifted from [index.html:15–21](design/suryaavala-com/project/index.html):
+
+```html
+<script is:inline>
+  (function() {
+    try {
+      var url = new URL(location.href);
+      var raw = url.searchParams.get('accent');
+      var MAP = {
+        purple: { brand: '#bd93f9', body: '#c4a0ff' },
+        cyan:   { brand: '#8be9fd', body: '#b4f0ff' },
+        green:  { brand: '#50fa7b', body: '#7effa0' },
+        orange: { brand: '#ffb86c', body: '#ffce99' },
+        pink:   { brand: '#ff79c6', body: '#ffa2d6' },
+      };
+      var k = raw && MAP[raw.toLowerCase()] ? raw.toLowerCase()
+              : (localStorage.getItem('sa-accent') || 'purple');
+      if (MAP[k]) {
+        document.documentElement.style.setProperty('--brand',      MAP[k].brand);
+        document.documentElement.style.setProperty('--brand-body', MAP[k].body);
+      }
+    } catch(e) {}
+  })();
+</script>
+```
+
+This duplicates the `ACCENT_MAP` constant once (intentionally) so the head-script remains zero-import. CI must enforce parity between this inline map and `/src/lib/accent.ts` via a unit test (`scripts/check-accent-parity.ts`) that string-greps both files and asserts identical hex pairs.
+
+### 6.4 The footer picker (Svelte sketch)
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { ACCENT_KEYS, ACCENT_MAP, applyAccent, persistAccent, readStoredAccent }
+    from '../lib/accent';
+  import type { AccentKey } from '../lib/accent';
+
+  let active: AccentKey = 'purple';
+
+  onMount(() => {
+    active = readStoredAccent();
+    // Keyboard accelerator: '?' scrolls to and focuses the picker.
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === '?' && !e.target?.matches?.('input,textarea,[contenteditable]')) {
+        document.getElementById('accent-picker')?.scrollIntoView({ behavior: 'smooth' });
+        (document.querySelector<HTMLButtonElement>('#accent-picker button'))?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  function pick(k: AccentKey) {
+    active = k;
+    applyAccent(k);
+    persistAccent(k);
+    // Emit analytics — see §9.
+    window.dispatchEvent(new CustomEvent('accent:changed',
+      { detail: { accent: k, source: 'picker' } }));
+  }
+</script>
+
+<fieldset id="accent-picker" class="accent-picker swatches">
+  <legend>Accent</legend>
+  {#each ACCENT_KEYS as key}
+    <button
+      type="button"
+      class:on={active === key}
+      aria-label={`Set accent to ${key}`}
+      aria-pressed={active === key}
+      style={`background: ${ACCENT_MAP[key].brand};`}
+      on:click={() => pick(key)}
+    />
+  {/each}
+</fieldset>
+```
+
+The styles reuse `.swatches` and `.swatches button` from [styles.css:455–464](design/suryaavala-com/project/styles.css). A new wrapper class `.accent-picker` only handles footer-row spacing and the `<legend>` label — no token changes.
+
+### 6.5 What changes in the existing prototype `applyAccent()` call site
+
+The function body at [app.js:41–46](design/suryaavala-com/project/app.js) is reused **verbatim** in `/src/lib/accent.ts`. The only behavioural delta is the addition of:
+
+* `readAccentParam(url)` — new
+* `bootAccent()` — new
+* The pre-FOUC `<script is:inline>` block — new
+
+Crucially, the existing `initAccent()` at [app.js:46](design/suryaavala-com/project/app.js) becomes a thin wrapper around `bootAccent()` — it no longer needs to read localStorage directly, because `bootAccent()` does. The dev Tweaks panel's swatch click handler at [app.js:714–719](design/suryaavala-com/project/app.js) imports `applyAccent` and `persistAccent` from `/src/lib/accent.ts` instead of mutating localStorage directly. The dev panel becomes a *consumer* of the same API the user picker uses.
+
+---
+
+## 7. Accessibility Considerations
+
+### 7.1 Contrast across all five accents
+
+The light-mode token sheet ([02_design.md §3.1 lines 113–138](02_design.md)) was tuned for `purple` as `--brand`. Three of the five presets (`green`, `orange`, `pink`) have AA-borderline contrast ratios against the `#ffffff` light-mode card surface when used as small body text.
+
+**Mitigation:** the `--brand-body` token is the brightened/darkened variant explicitly intended for "body-size purple text" ([01_design.md §3.1 WCAG note](01_design.md)). Every component that renders accent at body size already reads `--brand-body`, not `--brand`. We must **expand the same `--brand-body` discipline to the other four accents** and ship light-mode variants for each:
+
+| Key      | `--brand` (dark) | `--brand-body` (dark) | `--brand` (light) | `--brand-body` (light) |
+|----------|------------------|------------------------|-------------------|-------------------------|
+| `purple` | `#bd93f9`        | `#c4a0ff`              | `#5b21b6`         | `#5b21b6`               |
+| `cyan`   | `#8be9fd`        | `#b4f0ff`              | `#075e7a`         | `#075e7a`               |
+| `green`  | `#50fa7b`        | `#7effa0`              | `#0f6b34`         | `#0f6b34`               |
+| `orange` | `#ffb86c`        | `#ffce99`              | `#9a3412`         | `#9a3412`               |
+| `pink`   | `#ff79c6`        | `#ffa2d6`              | `#9d174d`         | `#9d174d`               |
+
+The light-mode hexes on the right come directly from the v2 light-mode token sheet ([02_design.md §3.1 lines 127–134](02_design.md)) — those are already shipped, AA-tuned, deeper variants. `applyAccent()` checks `documentElement.classList.contains('light')` and applies the appropriate column. CI runs an automated contrast audit (`axe-core` via `@playwright/test`) against all 10 combinations (5 accents × 2 themes) before every release.
+
+### 7.2 Focus-visible
+
+The site-wide `focus-visible` rule from [02_design.md §5.1](02_design.md) is `outline: 2px solid var(--brand)`. When a user picks `cyan`, every focus ring on the site instantly goes cyan. This is intended and desirable — it reinforces the accent choice on the action surface that needs it most.
+
+The picker swatches themselves must show a focus ring **distinct** from their fill colour, otherwise the cyan swatch with a cyan focus ring is invisible. Solution: focus-ring on swatches uses `var(--text)` not `var(--brand)`, scoped via:
+
+```css
+.accent-picker button:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 3px;
+}
+```
+
+### 7.3 Reduced motion
+
+The accent swap is currently instantaneous — `applyAccent()` mutates inline styles, no transitions on `--brand` consumers. This is good for `prefers-reduced-motion: reduce`. **No additional motion is added by this RFC.** The footer picker's `:hover { transform: scale(1.12) }` ([styles.css:463](design/suryaavala-com/project/styles.css)) is already wrapped by the existing reduced-motion guard in [styles.css:118–124](design/suryaavala-com/project/styles.css).
+
+The "Keep this accent?" toast uses a 200ms slide-in. It must be wrapped in:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .accent-toast { animation: none; opacity: 1; transform: none; }
+}
+```
+
+### 7.4 Screen-reader semantics
+
+* The picker is a `<fieldset>` with a `<legend>Accent</legend>`. SR users hear "Accent, group, 5 buttons."
+* Each swatch is `<button aria-label="Set accent to cyan" aria-pressed="true|false">`. The current selection is announced.
+* The `?` keyboard shortcut is documented in a visually-hidden `<p class="sr-only">` paragraph adjacent to the picker.
+* The toast is `role="status" aria-live="polite"`, *not* `role="alert"` — it's an offer, not an emergency.
+
+---
+
+## 8. Analytics
+
+The whole point of shipping the picker is to learn whether it matters. Without analytics, we can't decide whether to invest further (per-accent OGs, accent-based A/B tests, etc.).
+
+### 8.1 Events
+
+Three events. All fired client-side via the existing analytics shim (assumed: a thin wrapper over the chosen analytics provider; if no analytics provider is configured at production deploy, these become no-ops via feature flag).
+
+| Event name | When fired | Properties |
+|---|---|---|
+| `accent_changed` | Any accent change (picker or dev panel) | `{ accent: AccentKey, source: 'picker' \| 'param' \| 'dev_panel', previous: AccentKey \| null }` |
+| `accent_param_seen` | First paint where `?accent=<k>` was in the URL (whether or not the value was valid) | `{ raw: string, valid: boolean, accent: AccentKey \| null, referrer_host: string }` |
+| `accent_keep_decision` | User clicks `Keep` or `Dismiss` on the toast (or auto-dismiss fires) | `{ accent: AccentKey, decision: 'keep' \| 'dismiss' \| 'auto_dismiss', dwell_ms: number }` |
+
+### 8.2 Dimensions on every page-view
+
+A single dimension `accent` (one of the five keys) is attached to every page-view event. This lets us slice existing metrics (bounce rate, scroll depth, `/ping` modal opens, time-on-page) by the user's chosen accent. **Critical**: this dimension reflects the *active* accent at the moment of the page-view, not any historical preference. This avoids retroactive contamination of the existing dataset.
+
+### 8.3 What we will look at after 4 weeks
+
+| Question | Metric |
+|---|---|
+| Does anyone use it? | `% sessions with ≥1 accent_changed event` |
+| Which accents are picked? | Distribution of `accent_changed.accent` for `source = 'picker'` |
+| Does the share-link mechanic work? | `count(accent_param_seen.valid=true) / count(sessions)` |
+| Does the toast convert? | `count(accent_keep_decision.decision='keep') / count(accent_param_seen.valid=true)` |
+| Does choice correlate with behaviour? | `bounce_rate by dimension(accent)`; `/ping` modal-open rate by `dimension(accent)` |
+
+### 8.4 Privacy
+
+* No PII stored. Accent key is a single enum, not even a free-form value (the `accent_param_seen.raw` field is the only place a raw user input appears, and it's truncated to 32 chars).
+* No fingerprinting use of accent — explicitly **not** combined with viewport, UA, or theme to construct a synthetic ID. A note in the analytics SOP enforces this.
+* No cross-site / cross-domain transmission of the accent key.
+
+---
+
+## 9. Migration Plan
+
+### 9.1 Coexistence with the dev Tweaks panel
+
+Both surfaces:
+
+* Read from and write to the same `localStorage["sa-accent"]` key.
+* Call the same `applyAccent()` function from `/src/lib/accent.ts`.
+* Use the same five-preset `ACCENT_MAP`.
+
+This means a developer running the Claude Design preview can change the accent in either place and observe the same end state. The dev panel remains gated by `parent.postMessage({type: "__activate_edit_mode"})`; production users never see it. The user picker is always visible in the footer in production. There is no scenario where both surfaces disagree about the active accent because there is one source of truth.
+
+### 9.2 Phased rollout
+
+| Phase | What ships | Gating | Verification |
+|---|---|---|---|
+| **0 — Refactor** | Extract `ACCENT_MAP`, `applyAccent`, `persistAccent` into `/src/lib/accent.ts`. Dev panel imports from the new module. **Behavioural no-op.** | None | Existing Tweaks panel still works in preview. Storybook snapshot of all 5 dev-panel swatches unchanged. |
+| **1 — Pre-FOUC hook + boot logic** | Inline head script. `bootAccent()` runs on every page. **No new UI surface yet.** | None | Manual: `?accent=cyan` URL paints cyan immediately, strips param, no toast (toast not shipped yet). |
+| **2 — Footer picker** | `<AccentPicker>` Svelte island mounted in `<Layout>` footer. | None | Playwright e2e: pick each of 5 accents, verify CSS variables update, verify localStorage write, verify nav active-link colour reflects the change. |
+| **3 — Toast + keyboard accelerator** | `<AccentToast>` mounted at root; `?` keypress handler. | None | E2e: arrive at `?accent=cyan`, see toast, click Keep, verify localStorage. Same flow with Dismiss + auto-dismiss. |
+| **4 — Analytics** | Three events wired through analytics shim. `accent` dimension on page-views. | Behind a `ANALYTICS_ENABLED` env flag, defaulting on in production. | Verify events appear in analytics provider dashboard within 1h of canary deploy. |
+
+Each phase is independently revertible. If phase 3 misbehaves (toast covers a layout element, focus mis-restored, etc.) we revert just phase 3 without touching phases 0–2.
+
+### 9.3 Backwards compatibility with shared links
+
+There were no `?accent=*` links in production prior to this RFC. Phase 1 is the moment the param becomes meaningful. The team should announce the new param shape in `/notes` (a short post: *"You can now share suryaavala.com with a personal accent"*) only **after** Phase 4 lands, so analytics captures the attribution.
+
+### 9.4 Rollback plan
+
+If the picker creates more support burden than value (unlikely; flagged here for completeness):
+
+* Remove `<AccentPicker>` from `<Layout>` (1-line revert).
+* Remove the inline pre-FOUC script (1-line revert).
+* `localStorage["sa-accent"]` values written by users persist harmlessly — the dev panel can still read them, and they have no effect because the production site reverts to the hard-coded `--brand: #bd93f9`.
+* No data migration required.
+
+---
+
+## 10. Open Questions / Risks
+
+* **[OPEN]** Picker placement on `/notes` long-form pages: the footer there is far below the fold for any long article. Should the picker be sticky on `/notes` only? Out of scope for this RFC; note for v2.2.
+* **[OPEN]** Mobile footer-picker affordance: the `?` keyboard accelerator does not exist on mobile. Should there be a small "Theme" entry in a hamburger menu we don't yet have? Currently the site has no hamburger nav; adding one is bigger than this RFC. Defer.
+* **[OPEN]** Per-accent OG (option 5.1.ii) revisit: if `accent_param_seen` exceeds 5% of sessions over 4 weeks, escalate to a follow-on RFC for static per-accent OGs.
+* **[OPEN]** Light-mode contrast audit gap: the four non-purple accents have light-mode hexes proposed in §7.1, but those hexes have not been independently verified against every consumer of `--brand` in light mode (e.g., the Hero gradient-clipped text where contrast is harder to compute analytically). Phase 2 acceptance includes a manual axe-core sweep across all 10 (accent × theme) combinations, with any failure blocking the phase.
+* **[RISK — low]** Cache poisoning via `?accent=`: a malicious link could embed `?accent=<key>` to manipulate a user's first impression. Mitigated because (i) only five values are accepted, (ii) the value is silently ignored if invalid, (iii) the toast asks before persisting, (iv) the worst-case impact is a different brand colour for one session.
+* **[RISK — low]** Analytics dimension cardinality: adding an `accent` dimension to every page-view multiplies session-level reports by 5. Most analytics providers handle this trivially; flagged for completeness if our provider has cardinality limits.
+* **[RISK — medium]** `ACCENT_MAP` drift between the inline pre-FOUC script (§6.3) and `/src/lib/accent.ts` (§6.2). **Mitigation:** dedicated CI test (`scripts/check-accent-parity.ts`) parses both and fails the build on mismatch. Required gate for Phase 1.
+
+---
+
+## 11. Decision Summary
+
+| Sub-question | Recommendation |
+|---|---|
+| **(a)** Discoverability surface | **Footer-mounted picker** with a `?` keyboard accelerator. Reuses existing `.swatches` styles ([styles.css:455–464](design/suryaavala-com/project/styles.css)). No nav changes. |
+| **(b)** URL query-param shape & precedence | **`?accent=<key>`** with the **hybrid precedence rule**: param applies for the session, strip from URL, do not auto-persist; show a "Keep this accent?" toast that converts to persistence on user consent. |
+| **(c)** OG image strategy | **One canonical purple OG** for v2.1. Brand cohesion + zero runtime cost + reversible. Revisit per-accent OGs only if `accent_param_seen` exceeds 5% of sessions in the 4-week post-launch window. |


### PR DESCRIPTION
## Summary
- Adds `specs/02_design.md` — v2 visual/UX spec derived from the Claude Design handoff bundle (`specs/design/suryaavala-com/`). Inherits v1's tech stack, schema, and a11y/SEO contracts; replaces the visual language, component library, and homepage logic.
- Adds `specs/rfc_end_user_accent_picker.md` — resolves the v2 §7 OPEN question on a user-facing accent picker.

## What changed
- **`02_design.md` (~580 lines):** Dual-variant homepage (Safe Bento 9-card grid + Bold Editorial), dev-only Tweaks panel, status-board flippers, KPI strip, terminal sidebar, contact modal with G/L/E/W/C/S hotkeys, inline-SVG radar chart. Tokens lifted verbatim from `styles.css`; per-component CSS layered over a hand-authored `tokens.css` with Tailwind retained for utilities. Typed-data shapes (`Metric.method`, `Project.desc`, `Project.badge`) reconciled with the Claude bundle's `data.js` to fix v1 schema drift. Build-time `aggregates.industryCount` corrects the prototype's hard-coded "Four regulated industries" string (actual unique set across `D.experiences` is 5).
- **`rfc_end_user_accent_picker.md` (~560 lines):** Recommends footer-mounted swatch picker (reusing existing `.swatches` styles, with `?` keypress accelerator), `?accent=<key>` query param with hybrid consent-toast precedence (no silent localStorage overwrite, URL cleaned via `history.replaceState`), and a single canonical purple OG for v2.1 — revisit per-accent OGs only if `accent_param_seen` exceeds 5% of sessions in the 4-week post-launch window.

## Why
- v1 spec was Gemini-derived. The Claude Design bundle in `specs/design/suryaavala-com/` ships a more refined visual vocabulary; v2 keeps the architecture stable and swaps the UI layer.
- The dev-only Tweaks panel leaves a UX gap for end users wanting personal expression / share-link colour cohesion. The RFC closes it before any implementation PR lands.

## Reviewer notes
- Specs only — no code changes. Astro app is untouched.
- v1 (`01_design.md`) is unchanged and remains the parent for §2 (architecture), §5 (a11y/SEO/CSP), and §6 (data integrity / Zod schemas). v2 calls out every delta explicitly.
- Spec was self-reviewed via an independent sub-agent pass; field-name reconciliations and the "5 industries" fix come from that review. Two intentional v2 deltas vs the Claude prototype: (1) `pingLogo()` must extend with 12 stack-glyph SVGs (the prototype renders empty `<i></i>` placeholders), (2) modal focus trap is a v2 must-fix.

## Test plan
- [ ] Spec review by domain owner (design + a11y)
- [ ] Verify cited line numbers in `app.js` / `styles.css` / `home-bold.css` / `pages.css` resolve to the claimed components
- [ ] Cross-check `02_design.md §6.x` typed-data deltas against existing `/src/data/*.ts` modules before any implementation PR opens
- [ ] Confirm RFC recommendations satisfy each part of the v2 §7 OPEN question (a) discoverability, (b) query-param, (c) OG strategy
- [ ] Decide whether the "5 industries" fix should also land as a one-line correction to the Claude prototype's `app.js:396`